### PR TITLE
Issue 32 Optimize move generator

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -17,14 +17,14 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
 
       - name: Build the Rust project
         run: cd ai-engine && cargo build --verbose --all
 
       - name: Run tests
-        run: cd ai-engine && cargo test --verbose --all
+        run: cd ai-engine && cargo +nightly test -r -- --test-threads=1 -Z unstable-options --report-time
   rustfmt:
     name: Source formatter
     runs-on: ubuntu-latest

--- a/ai-engine/Cargo.toml
+++ b/ai-engine/Cargo.toml
@@ -15,7 +15,7 @@ lto = true
 opt-level = 3
 panic = "abort"
 strip = true
-debug = true
+# debug = true
 
 [dependencies]
 actix-cors = "0.7.0"

--- a/ai-engine/src/game_bit_board/_move/_move.rs
+++ b/ai-engine/src/game_bit_board/_move/_move.rs
@@ -36,6 +36,15 @@ pub struct Move {
     en_passant_bb_piece_square: u64,
     color: Color,
     piece_type: PieceType,
+
+    // Board state before making this move
+    pub castling_rights: u8,
+    pub bitboards: [u64; 8],
+    pub board_en_passant_bb_position: u64,
+    pub board_en_passant_bb_piece_square: u64,
+    pub black_king_moved: bool,
+    pub white_king_moved: bool,
+    pub zobrist_hash: u64,
 }
 
 impl PartialEq for Move {
@@ -110,6 +119,14 @@ impl Move {
             en_passant_bb_piece_square: 0,
             color,
             piece_type,
+
+            castling_rights: 0,
+            bitboards: [0; 8],
+            board_en_passant_bb_position: 0,
+            board_en_passant_bb_piece_square: 0,
+            black_king_moved: false,
+            white_king_moved: false,
+            zobrist_hash: 0,
         }
     }
 

--- a/ai-engine/src/game_bit_board/_move/_move.rs
+++ b/ai-engine/src/game_bit_board/_move/_move.rs
@@ -72,7 +72,7 @@ impl fmt::Display for Move {
 }
 
 impl Move {
-    // For test purposes
+    /// For test purposes
     pub fn dummy_from_to(from: usize, to: usize) -> Self {
         if cfg!(test) {
             Move::with_flags(0, from, to, Color::Black, PieceType::Empty)
@@ -81,7 +81,7 @@ impl Move {
         }
     }
 
-    // For test purposes
+    /// For test purposes
     pub fn dummy_with_flags(flags: u16, from: usize, to: usize) -> Self {
         if cfg!(test) {
             Move::with_flags(flags, from, to, Color::Black, PieceType::Empty)

--- a/ai-engine/src/game_bit_board/_move/moves_counter.rs
+++ b/ai-engine/src/game_bit_board/_move/moves_counter.rs
@@ -25,7 +25,7 @@ fn _count_moves(
     lookup_table: &mut HashMap<(u64, usize), u64>,
 ) -> u64 {
     if depth == 0 || board.is_game_finished() {
-        // lookup_table.insert((board.get_zobrist_hash(), depth), 1);
+        lookup_table.insert((board.get_zobrist_hash(), depth), 1);
 
         return 1;
     }
@@ -39,15 +39,16 @@ fn _count_moves(
     moves.iter().for_each(|_move| {
         board.move_piece(_move);
 
-        // let table_key = (board.get_zobrist_hash(), new_depth);
+        let table_key = (board.get_zobrist_hash(), new_depth);
 
-        // let moves_count = if lookup_table.contains_key(&table_key) {
-        //     *lookup_table.get(&table_key).unwrap()
-        // } else {
-        //     _count_moves(board, new_depth, false, move_generator, lookup_table)
-        // };
+        let moves_count = if lookup_table.contains_key(&table_key) {
+            *lookup_table.get(&table_key).unwrap()
+        } else {
+            _count_moves(board, new_depth, false, move_generator, lookup_table)
+        };
 
-        let moves_count = _count_moves(board, new_depth, false, move_generator, lookup_table);
+        // let moves_count = _count_moves(board, new_depth, false, move_generator,
+        // lookup_table);
 
         num_positions += moves_count;
 
@@ -58,7 +59,7 @@ fn _count_moves(
         board.unmake_last_move();
     });
 
-    // lookup_table.insert((board.get_zobrist_hash(), depth), num_positions);
+    lookup_table.insert((board.get_zobrist_hash(), depth), num_positions);
 
     num_positions
 }

--- a/ai-engine/src/game_bit_board/_move/moves_counter.rs
+++ b/ai-engine/src/game_bit_board/_move/moves_counter.rs
@@ -30,13 +30,13 @@ fn _count_moves(
         return 1;
     }
 
-    let moves = move_generator.get_moves(board);
+    let mut moves = move_generator.get_moves(board);
 
     let mut num_positions = 0;
 
     let new_depth = depth - 1;
 
-    moves.iter().for_each(|_move| {
+    moves.iter_mut().for_each(|_move| {
         board.move_piece(_move);
 
         let table_key = (board.get_zobrist_hash(), new_depth);

--- a/ai-engine/src/game_bit_board/_move/moves_counter.rs
+++ b/ai-engine/src/game_bit_board/_move/moves_counter.rs
@@ -105,6 +105,7 @@ mod moves_counter_test {
         results.push((3, 8_902));
         results.push((4, 197_281));
         results.push((5, 4_865_609));
+        results.push((6, 119_060_324));
 
         assert_fen_moves(
             String::from("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"),
@@ -123,6 +124,7 @@ mod moves_counter_test {
         results.push((2, 2_039));
         results.push((3, 97_862));
         results.push((4, 4_085_603));
+        results.push((5, 193_690_690));
 
         assert_fen_moves(
             String::from("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -"),
@@ -142,6 +144,8 @@ mod moves_counter_test {
         results.push((3, 2_812));
         results.push((4, 43_238));
         results.push((5, 674_624));
+        results.push((6, 11_030_083));
+        results.push((7, 178_633_661));
 
         assert_fen_moves(
             String::from("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -"),
@@ -160,6 +164,7 @@ mod moves_counter_test {
         results.push((2, 264));
         results.push((3, 9_467));
         results.push((4, 422_333));
+        results.push((5, 15_833_292));
 
         assert_fen_moves(
             String::from("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1"),
@@ -178,6 +183,7 @@ mod moves_counter_test {
         results.push((2, 1486));
         results.push((3, 62_379));
         results.push((4, 2_103_487));
+        results.push((5, 89_941_194));
 
         assert_fen_moves(
             String::from("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8"),
@@ -196,6 +202,7 @@ mod moves_counter_test {
         results.push((2, 2_079));
         results.push((3, 89_890));
         results.push((4, 3_894_594));
+        results.push((5, 164_075_551));
 
         assert_fen_moves(
             String::from(

--- a/ai-engine/src/game_bit_board/_move/moves_counter.rs
+++ b/ai-engine/src/game_bit_board/_move/moves_counter.rs
@@ -17,6 +17,8 @@ pub fn count_moves(
         println!("\nTime spent: {:#?}", start.elapsed());
     }
 
+    // println!("There are {} elements in the hashmap", lookup_table.len());
+
     result
 }
 
@@ -25,7 +27,7 @@ fn _count_moves(
     lookup_table: &mut HashMap<(u64, usize), u64>,
 ) -> u64 {
     if depth == 0 || board.is_game_finished() {
-        lookup_table.insert((board.get_zobrist_hash(), depth), 1);
+        // lookup_table.insert((board.get_zobrist_hash(), depth), 1);
 
         return 1;
     }
@@ -39,16 +41,16 @@ fn _count_moves(
     moves.iter_mut().for_each(|_move| {
         board.move_piece(_move);
 
-        let table_key = (board.get_zobrist_hash(), new_depth);
+        // let table_key = (board.get_zobrist_hash(), new_depth);
 
-        let moves_count = if lookup_table.contains_key(&table_key) {
-            *lookup_table.get(&table_key).unwrap()
-        } else {
-            _count_moves(board, new_depth, false, move_generator, lookup_table)
-        };
+        // let moves_count = if lookup_table.contains_key(&table_key) {
+        //     *lookup_table.get(&table_key).unwrap()
+        // } else {
+        //     _count_moves(board, new_depth, false, move_generator, lookup_table)
+        // };
 
-        // let moves_count = _count_moves(board, new_depth, false, move_generator,
-        // lookup_table);
+        let moves_count = _count_moves(board, new_depth, false, move_generator,
+        lookup_table);
 
         num_positions += moves_count;
 
@@ -59,7 +61,7 @@ fn _count_moves(
         board.unmake_last_move();
     });
 
-    lookup_table.insert((board.get_zobrist_hash(), depth), num_positions);
+    // lookup_table.insert((board.get_zobrist_hash(), depth), num_positions);
 
     num_positions
 }

--- a/ai-engine/src/game_bit_board/_move/moves_counter.rs
+++ b/ai-engine/src/game_bit_board/_move/moves_counter.rs
@@ -49,8 +49,7 @@ fn _count_moves(
         //     _count_moves(board, new_depth, false, move_generator, lookup_table)
         // };
 
-        let moves_count = _count_moves(board, new_depth, false, move_generator,
-        lookup_table);
+        let moves_count = _count_moves(board, new_depth, false, move_generator, lookup_table);
 
         num_positions += moves_count;
 

--- a/ai-engine/src/game_bit_board/_move/moves_counter.rs
+++ b/ai-engine/src/game_bit_board/_move/moves_counter.rs
@@ -11,9 +11,11 @@ pub fn count_moves(
 
     let result = _count_moves(board, depth, track_moves, move_generator, &mut lookup_table);
 
-    println!("Total: {result}");
+    if track_moves {
+        println!("Total: {result}");
 
-    println!("\nTime spent: {:#?}", start.elapsed());
+        println!("\nTime spent: {:#?}", start.elapsed());
+    }
 
     result
 }
@@ -62,41 +64,142 @@ fn _count_moves(
 }
 
 #[cfg(test)]
-mod tests {
+mod moves_counter_test {
+    use std::sync::Mutex;
+
+    use once_cell::sync::Lazy;
+
     use crate::game_bit_board::{
         _move::moves_counter::count_moves, board::Board,
         move_generator::move_generator::MoveGenerator,
     };
 
+    static MOVE_GENERATOR: Lazy<Mutex<MoveGenerator>> =
+        Lazy::new(|| Mutex::new(MoveGenerator::new()));
+
+    fn assert_fen_moves(fen: String, move_generator: &MoveGenerator, resuls: Vec<(usize, u64)>) {
+        println!("\nPerft position {fen}");
+        let mut board = Board::from_fen(fen.as_str());
+
+        for (depth, expected_result) in resuls {
+            print!("Depth {depth}: ");
+            assert_eq!(
+                count_moves(&mut board, depth, false, move_generator),
+                expected_result
+            );
+            println!("OK!");
+        }
+    }
+
     #[test]
-    fn test_move_generation_count() {
-        let mut board = Board::new();
-        let mut move_generator = MoveGenerator::new();
-        // Positions for initial FEN
+    fn test_perft_pos_1() {
+        let move_generator = MOVE_GENERATOR.lock().unwrap();
 
-        assert_eq!(count_moves(&mut board, 1, false, &mut move_generator), 20);
-        assert_eq!(count_moves(&mut board, 2, false, &mut move_generator), 400);
-        assert_eq!(
-            count_moves(&mut board, 3, false, &mut move_generator),
-            8_902
+        let mut results = Vec::new();
+
+        results.push((1, 20));
+        results.push((2, 400));
+        results.push((3, 8_902));
+        results.push((4, 197_281));
+        results.push((5, 4_865_609));
+
+        assert_fen_moves(
+            String::from("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"),
+            &move_generator,
+            results,
         );
-        // assert_eq!(count_moves(&mut board, 4, false, &move_generator),
-        // 197_281); assert_eq!(
-        //     count_moves(&mut board, 5, false, &move_generator),
-        //     4_865_609
-        // );
-        // assert_eq!(
-        //     count_moves(&mut board, 6, false, &move_generator),
-        //     119_060_324
-        // );
+    }
 
-        // board
-        //     .load_position("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/
-        // PPPBBPPP/R3K2R w KQkq -");
+    #[test]
+    fn test_perft_pos_2() {
+        let move_generator = MOVE_GENERATOR.lock().unwrap();
 
-        // assert_eq!(count_moves(&mut board, 1, false), 48);
-        // assert_eq!(count_moves(&mut board, 2, false), 2_039);
-        // assert_eq!(count_moves(&mut board, 3, false), 97_862);
-        // assert_eq!(count_moves(&mut board, 4, false), 4_085_603);
+        let mut results = Vec::new();
+
+        results.push((1, 48));
+        results.push((2, 2_039));
+        results.push((3, 97_862));
+        results.push((4, 4_085_603));
+
+        assert_fen_moves(
+            String::from("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -"),
+            &move_generator,
+            results,
+        );
+    }
+
+    #[test]
+    fn test_perft_pos_3() {
+        let move_generator = MOVE_GENERATOR.lock().unwrap();
+
+        let mut results = Vec::new();
+
+        results.push((1, 14));
+        results.push((2, 191));
+        results.push((3, 2_812));
+        results.push((4, 43_238));
+        results.push((5, 674_624));
+
+        assert_fen_moves(
+            String::from("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -"),
+            &move_generator,
+            results,
+        );
+    }
+
+    #[test]
+    fn test_perft_pos_4() {
+        let move_generator = MOVE_GENERATOR.lock().unwrap();
+
+        let mut results = Vec::new();
+
+        results.push((1, 6));
+        results.push((2, 264));
+        results.push((3, 9_467));
+        results.push((4, 422_333));
+
+        assert_fen_moves(
+            String::from("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1"),
+            &move_generator,
+            results,
+        );
+    }
+
+    #[test]
+    fn test_perft_pos_5() {
+        let move_generator = MOVE_GENERATOR.lock().unwrap();
+
+        let mut results = Vec::new();
+
+        results.push((1, 44));
+        results.push((2, 1486));
+        results.push((3, 62_379));
+        results.push((4, 2_103_487));
+
+        assert_fen_moves(
+            String::from("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8"),
+            &move_generator,
+            results,
+        );
+    }
+
+    #[test]
+    fn test_perft_pos_6() {
+        let move_generator = MOVE_GENERATOR.lock().unwrap();
+
+        let mut results = Vec::new();
+
+        results.push((1, 46));
+        results.push((2, 2_079));
+        results.push((3, 89_890));
+        results.push((4, 3_894_594));
+
+        assert_fen_moves(
+            String::from(
+                "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10",
+            ),
+            &move_generator,
+            results,
+        );
     }
 }

--- a/ai-engine/src/game_bit_board/_move/moves_counter.rs
+++ b/ai-engine/src/game_bit_board/_move/moves_counter.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, time::Instant};
 use crate::game_bit_board::{board::Board, move_generator::move_generator::MoveGenerator};
 
 pub fn count_moves(
-    board: &mut Board, depth: usize, track_moves: bool, move_generator: &mut MoveGenerator,
+    board: &mut Board, depth: usize, track_moves: bool, move_generator: &MoveGenerator,
 ) -> u64 {
     let mut lookup_table = HashMap::new();
 
@@ -19,7 +19,7 @@ pub fn count_moves(
 }
 
 fn _count_moves(
-    board: &mut Board, depth: usize, track_moves: bool, move_generator: &mut MoveGenerator,
+    board: &mut Board, depth: usize, track_moves: bool, move_generator: &MoveGenerator,
     lookup_table: &mut HashMap<(u64, usize), u64>,
 ) -> u64 {
     if depth == 0 || board.is_game_finished() {
@@ -37,13 +37,15 @@ fn _count_moves(
     moves.iter().for_each(|_move| {
         board.move_piece(_move);
 
-        let table_key = (board.get_zobrist_hash(), new_depth);
+        // let table_key = (board.get_zobrist_hash(), new_depth);
 
-        let moves_count = if lookup_table.contains_key(&table_key) {
-            *lookup_table.get(&table_key).unwrap()
-        } else {
-            _count_moves(board, new_depth, false, move_generator, lookup_table)
-        };
+        // let moves_count = if lookup_table.contains_key(&table_key) {
+        //     *lookup_table.get(&table_key).unwrap()
+        // } else {
+        //     _count_moves(board, new_depth, false, move_generator, lookup_table)
+        // };
+
+        let moves_count = _count_moves(board, new_depth, false, move_generator, lookup_table);
 
         num_positions += moves_count;
 
@@ -54,7 +56,7 @@ fn _count_moves(
         board.unmake_last_move();
     });
 
-    lookup_table.insert((board.get_zobrist_hash(), depth), num_positions);
+    // lookup_table.insert((board.get_zobrist_hash(), depth), num_positions);
 
     num_positions
 }

--- a/ai-engine/src/game_bit_board/_move/moves_counter.rs
+++ b/ai-engine/src/game_bit_board/_move/moves_counter.rs
@@ -23,7 +23,7 @@ fn _count_moves(
     lookup_table: &mut HashMap<(u64, usize), u64>,
 ) -> u64 {
     if depth == 0 || board.is_game_finished() {
-        lookup_table.insert((board.get_zobrist_hash(), depth), 1);
+        // lookup_table.insert((board.get_zobrist_hash(), depth), 1);
 
         return 1;
     }

--- a/ai-engine/src/game_bit_board/_move/moves_counter.rs
+++ b/ai-engine/src/game_bit_board/_move/moves_counter.rs
@@ -1,14 +1,10 @@
-
-use std::{
-    collections::HashMap, time::Instant
-};
+use std::{collections::HashMap, time::Instant};
 
 use crate::game_bit_board::{board::Board, move_generator::move_generator::MoveGenerator};
 
 pub fn count_moves(
     board: &mut Board, depth: usize, track_moves: bool, move_generator: &mut MoveGenerator,
 ) -> u64 {
-    
     let mut lookup_table = HashMap::new();
 
     let start = Instant::now();
@@ -24,12 +20,11 @@ pub fn count_moves(
 
 fn _count_moves(
     board: &mut Board, depth: usize, track_moves: bool, move_generator: &mut MoveGenerator,
-    lookup_table: &mut HashMap<(u64, usize), u64>
+    lookup_table: &mut HashMap<(u64, usize), u64>,
 ) -> u64 {
- 
     if depth == 0 || board.is_game_finished() {
         lookup_table.insert((board.get_zobrist_hash(), depth), 1);
-        
+
         return 1;
     }
 
@@ -79,7 +74,10 @@ mod tests {
 
         assert_eq!(count_moves(&mut board, 1, false, &mut move_generator), 20);
         assert_eq!(count_moves(&mut board, 2, false, &mut move_generator), 400);
-        assert_eq!(count_moves(&mut board, 3, false, &mut move_generator), 8_902);
+        assert_eq!(
+            count_moves(&mut board, 3, false, &mut move_generator),
+            8_902
+        );
         // assert_eq!(count_moves(&mut board, 4, false, &move_generator),
         // 197_281); assert_eq!(
         //     count_moves(&mut board, 5, false, &move_generator),

--- a/ai-engine/src/game_bit_board/board.rs
+++ b/ai-engine/src/game_bit_board/board.rs
@@ -281,7 +281,7 @@ impl Board {
             .push(self.en_passant_bb_piece_square);
         self.black_king_moved_history.push(self.black_king_moved);
         self.white_king_moved_history.push(self.white_king_moved);
-        self.moves_history.push(_move);
+        // self.moves_history.push(_move);
         self.zobrist_history.push(self.zobrist.clone());
     }
 
@@ -324,13 +324,14 @@ impl Board {
     }
 
     pub fn move_piece(&mut self, _move: &Move) {
-        if self.get_piece_color(_move.get_from()) != self.side_to_move {
+        let color = self.get_piece_color(_move.get_from());
+
+        if color != self.side_to_move {
             panic!("Invalid player move, it's not your turn. {_move}")
         }
 
         self.save_current_state(_move.clone());
 
-        let color = self.get_piece_color(_move.get_from());
         let mut piece_type = self.get_piece_type(_move.get_from());
 
         let from_square = _move.get_from();

--- a/ai-engine/src/game_bit_board/board.rs
+++ b/ai-engine/src/game_bit_board/board.rs
@@ -161,6 +161,7 @@ impl Board {
         match parts[3] {
             "-" => {
                 board.en_passant_bb_position = 0;
+                board.en_passant_bb_piece_square = 0;
             }
             pos => {
                 let bb_position = to_bitboard_position(algebraic_to_square(pos) as u64);

--- a/ai-engine/src/game_bit_board/board.rs
+++ b/ai-engine/src/game_bit_board/board.rs
@@ -798,7 +798,11 @@ mod tests {
 
         board.display();
 
-        board.move_piece(&Move::dummy_with_flags(EN_PASSANT, Squares::D5, Squares::C6));
+        board.move_piece(&Move::dummy_with_flags(
+            EN_PASSANT,
+            Squares::D5,
+            Squares::C6,
+        ));
 
         board.display();
 

--- a/ai-engine/src/game_bit_board/board.rs
+++ b/ai-engine/src/game_bit_board/board.rs
@@ -38,15 +38,7 @@ pub struct Board {
     full_move_clock: u32,
     half_move_clock: u32,
 
-    // Stacks used to unmake moves
-    // castling_rights_history: Vec<u8>,
-    // bitboards_history: Vec<[u64; 8]>,
-    // en_passant_bb_position_history: Vec<u64>,
-    // en_passant_bb_piece_square_history: Vec<u64>,
-    // black_king_moved_history: Vec<bool>,
-    // white_king_moved_history: Vec<bool>,
     moves_history: Vec<Move>,
-    // zobrist_history: Vec<Zobrist>,
     zobrist: Zobrist,
 }
 
@@ -92,16 +84,7 @@ impl Board {
             winner: None,
             full_move_clock: 1,
             half_move_clock: 0,
-
-            // castling_rights_history: Vec::new(),
-            // bitboards_history: Vec::new(),
-            // en_passant_bb_position_history: Vec::new(),
-            // en_passant_bb_piece_square_history: Vec::new(),
-            // black_king_moved_history: Vec::new(),
-            // white_king_moved_history: Vec::new(),
             moves_history: Vec::new(),
-            // zobrist_history: Vec::new(),
-
             zobrist: Zobrist::new(),
         }
     }
@@ -285,12 +268,10 @@ impl Board {
 
         let mut _move = self.moves_history.last().unwrap().clone();
 
-        self.unmake_move(
-            &mut _move
-        );
+        self.unmake_move(&mut _move);
     }
 
-    pub fn unmake_move(&mut self, _move: &mut Move) {
+    fn unmake_move(&mut self, _move: &mut Move) {
         self.castling_rights = _move.castling_rights;
         self.bitboards = _move.bitboards;
         self.en_passant_bb_position = _move.board_en_passant_bb_position;
@@ -311,31 +292,7 @@ impl Board {
             self.winner = None;
         }
 
-        let mut _move = self.moves_history.remove(self.moves_history.len() - 1);
-
-        // if self.castling_rights_history.len() == 0 {
-        //     return;
-        // }
-
-        // self.castling_rights = self
-        //     .castling_rights_history
-        //     .remove(self.castling_rights_history.len() - 1);
-        // self.bitboards = self
-        //     .bitboards_history
-        //     .remove(self.bitboards_history.len() - 1);
-        // self.en_passant_bb_position = self
-        //     .en_passant_bb_position_history
-        //     .remove(self.en_passant_bb_position_history.len() - 1);
-        // self.en_passant_piece_square_bb = self
-        //     .en_passant_bb_piece_square_history
-        //     .remove(self.en_passant_bb_piece_square_history.len() - 1);
-        // self.black_king_moved = self
-        //     .black_king_moved_history
-        //     .remove(self.black_king_moved_history.len() - 1);
-        // self.white_king_moved = self
-        //     .white_king_moved_history
-        //     .remove(self.white_king_moved_history.len() - 1);
-        // self.zobrist = self.zobrist_history.remove(self.zobrist_history.len() - 1);
+        self.moves_history.remove(self.moves_history.len() - 1);
     }
 
     pub fn move_piece(&mut self, _move: &mut Move) {
@@ -362,8 +319,6 @@ impl Board {
                 piece_type,
                 self.en_passant_piece_square_bb,
             );
-            // self.en_passant_bb_position = 0;
-            // self.en_passant_piece_square_bb = 0;
         }
 
         // When a move is made and en passant is available, remove it
@@ -623,7 +578,7 @@ impl Board {
             fen.push('-');
         } else {
             let mut pos = self.en_passant_bb_position.clone();
-            fen.push_str(&square_to_algebraic(pop_lsb(&mut pos) as usize)); // Assuming a helper for conversion
+            fen.push_str(&square_to_algebraic(pop_lsb(&mut pos) as usize));
         }
 
         // Add halfmove clock

--- a/ai-engine/src/game_bit_board/board.rs
+++ b/ai-engine/src/game_bit_board/board.rs
@@ -39,14 +39,14 @@ pub struct Board {
     half_move_clock: u32,
 
     // Stacks used to unmake moves
-    castling_rights_history: Vec<u8>,
-    bitboards_history: Vec<[u64; 8]>,
-    en_passant_bb_position_history: Vec<u64>,
-    en_passant_bb_piece_square_history: Vec<u64>,
-    black_king_moved_history: Vec<bool>,
-    white_king_moved_history: Vec<bool>,
+    // castling_rights_history: Vec<u8>,
+    // bitboards_history: Vec<[u64; 8]>,
+    // en_passant_bb_position_history: Vec<u64>,
+    // en_passant_bb_piece_square_history: Vec<u64>,
+    // black_king_moved_history: Vec<bool>,
+    // white_king_moved_history: Vec<bool>,
     moves_history: Vec<Move>,
-    zobrist_history: Vec<Zobrist>,
+    // zobrist_history: Vec<Zobrist>,
     zobrist: Zobrist,
 }
 
@@ -93,14 +93,14 @@ impl Board {
             full_move_clock: 1,
             half_move_clock: 0,
 
-            castling_rights_history: Vec::new(),
-            bitboards_history: Vec::new(),
-            en_passant_bb_position_history: Vec::new(),
-            en_passant_bb_piece_square_history: Vec::new(),
-            black_king_moved_history: Vec::new(),
-            white_king_moved_history: Vec::new(),
+            // castling_rights_history: Vec::new(),
+            // bitboards_history: Vec::new(),
+            // en_passant_bb_position_history: Vec::new(),
+            // en_passant_bb_piece_square_history: Vec::new(),
+            // black_king_moved_history: Vec::new(),
+            // white_king_moved_history: Vec::new(),
             moves_history: Vec::new(),
-            zobrist_history: Vec::new(),
+            // zobrist_history: Vec::new(),
 
             zobrist: Zobrist::new(),
         }
@@ -267,43 +267,37 @@ impl Board {
         self.bitboards[get_piece_type_index(piece_type)] ^= bb_position;
     }
 
-    fn save_current_state(&mut self, _move: Move) {
-        self.castling_rights_history.push(self.castling_rights);
-        self.bitboards_history.push(self.bitboards);
-        self.en_passant_bb_position_history
-            .push(self.en_passant_bb_position);
-        self.en_passant_bb_piece_square_history
-            .push(self.en_passant_piece_square_bb);
-        self.black_king_moved_history.push(self.black_king_moved);
-        self.white_king_moved_history.push(self.white_king_moved);
-        // self.moves_history.push(_move);
-        self.zobrist_history.push(self.zobrist.clone());
+    fn save_current_state(&mut self, _move: &mut Move) {
+        _move.castling_rights = self.castling_rights;
+        _move.bitboards = self.bitboards;
+        _move.board_en_passant_bb_position = self.en_passant_bb_position;
+        _move.board_en_passant_bb_piece_square = self.en_passant_piece_square_bb;
+        _move.black_king_moved = self.black_king_moved;
+        _move.white_king_moved = self.white_king_moved;
+        _move.zobrist_hash = self.zobrist.get_hash();
+        self.moves_history.push(_move.clone());
     }
 
     pub fn unmake_last_move(&mut self) {
-        if self.castling_rights_history.len() == 0 {
-            return;
+        if self.moves_history.len() == 0 {
+            panic!("Can't make unmove");
         }
 
-        self.castling_rights = self
-            .castling_rights_history
-            .remove(self.castling_rights_history.len() - 1);
-        self.bitboards = self
-            .bitboards_history
-            .remove(self.bitboards_history.len() - 1);
-        self.en_passant_bb_position = self
-            .en_passant_bb_position_history
-            .remove(self.en_passant_bb_position_history.len() - 1);
-        self.en_passant_piece_square_bb = self
-            .en_passant_bb_piece_square_history
-            .remove(self.en_passant_bb_piece_square_history.len() - 1);
-        self.black_king_moved = self
-            .black_king_moved_history
-            .remove(self.black_king_moved_history.len() - 1);
-        self.white_king_moved = self
-            .white_king_moved_history
-            .remove(self.white_king_moved_history.len() - 1);
-        self.zobrist = self.zobrist_history.remove(self.zobrist_history.len() - 1);
+        let mut _move = self.moves_history.last().unwrap().clone();
+
+        self.unmake_move(
+            &mut _move
+        );
+    }
+
+    pub fn unmake_move(&mut self, _move: &mut Move) {
+        self.castling_rights = _move.castling_rights;
+        self.bitboards = _move.bitboards;
+        self.en_passant_bb_position = _move.board_en_passant_bb_position;
+        self.en_passant_piece_square_bb = _move.board_en_passant_bb_piece_square;
+        self.black_king_moved = _move.black_king_moved;
+        self.white_king_moved = _move.white_king_moved;
+        self.zobrist.set_hash(_move.zobrist_hash);
 
         if self.side_to_move.is_white() {
             self.full_move_clock -= 1;
@@ -316,16 +310,42 @@ impl Board {
         if self.winner.is_some() {
             self.winner = None;
         }
+
+        let mut _move = self.moves_history.remove(self.moves_history.len() - 1);
+
+        // if self.castling_rights_history.len() == 0 {
+        //     return;
+        // }
+
+        // self.castling_rights = self
+        //     .castling_rights_history
+        //     .remove(self.castling_rights_history.len() - 1);
+        // self.bitboards = self
+        //     .bitboards_history
+        //     .remove(self.bitboards_history.len() - 1);
+        // self.en_passant_bb_position = self
+        //     .en_passant_bb_position_history
+        //     .remove(self.en_passant_bb_position_history.len() - 1);
+        // self.en_passant_piece_square_bb = self
+        //     .en_passant_bb_piece_square_history
+        //     .remove(self.en_passant_bb_piece_square_history.len() - 1);
+        // self.black_king_moved = self
+        //     .black_king_moved_history
+        //     .remove(self.black_king_moved_history.len() - 1);
+        // self.white_king_moved = self
+        //     .white_king_moved_history
+        //     .remove(self.white_king_moved_history.len() - 1);
+        // self.zobrist = self.zobrist_history.remove(self.zobrist_history.len() - 1);
     }
 
-    pub fn move_piece(&mut self, _move: &Move) {
+    pub fn move_piece(&mut self, _move: &mut Move) {
         let color = self.get_piece_color(_move.get_from());
 
         if color != self.side_to_move {
             panic!("Invalid player move, it's not your turn. {_move}")
         }
 
-        self.save_current_state(_move.clone());
+        self.save_current_state(_move);
 
         let mut piece_type = self.get_piece_type(_move.get_from());
 
@@ -661,9 +681,9 @@ mod tests {
 
         assert_eq!(0xF, board.castling_rights);
 
-        board.move_piece(&Move::dummy_from_to(Squares::D2, Squares::D4));
-        board.move_piece(&Move::dummy_from_to(Squares::D7, Squares::D5));
-        board.move_piece(&Move::dummy_from_to(Squares::E1, Squares::D2));
+        board.move_piece(&mut Move::dummy_from_to(Squares::D2, Squares::D4));
+        board.move_piece(&mut Move::dummy_from_to(Squares::D7, Squares::D5));
+        board.move_piece(&mut Move::dummy_from_to(Squares::E1, Squares::D2));
 
         board.display();
 
@@ -685,7 +705,7 @@ mod tests {
             "Default castling rights should be available"
         );
 
-        board.move_piece(&Move::dummy_from_to(Squares::A1, Squares::B1));
+        board.move_piece(&mut Move::dummy_from_to(Squares::A1, Squares::B1));
 
         board.display();
 
@@ -694,8 +714,8 @@ mod tests {
             board.castling_rights & Board::WHITE_QUEEN_SIDE_CASTLING_RIGHT
         );
 
-        board.move_piece(&Move::dummy_from_to(Squares::H7, Squares::H6));
-        board.move_piece(&Move::dummy_from_to(Squares::H1, Squares::G1));
+        board.move_piece(&mut Move::dummy_from_to(Squares::H7, Squares::H6));
+        board.move_piece(&mut Move::dummy_from_to(Squares::H1, Squares::G1));
 
         board.display();
 
@@ -712,8 +732,8 @@ mod tests {
 
         assert_eq!(0xF, board.castling_rights);
 
-        board.move_piece(&Move::dummy_from_to(Squares::E2, Squares::E3));
-        board.move_piece(&Move::dummy_from_to(Squares::E8, Squares::D7));
+        board.move_piece(&mut Move::dummy_from_to(Squares::E2, Squares::E3));
+        board.move_piece(&mut Move::dummy_from_to(Squares::E8, Squares::D7));
 
         board.display();
 
@@ -735,8 +755,8 @@ mod tests {
             "Default castling rights should be available"
         );
 
-        board.move_piece(&Move::dummy_from_to(Squares::A2, Squares::A3));
-        board.move_piece(&Move::dummy_from_to(Squares::A8, Squares::B8));
+        board.move_piece(&mut Move::dummy_from_to(Squares::A2, Squares::A3));
+        board.move_piece(&mut Move::dummy_from_to(Squares::A8, Squares::B8));
 
         board.display();
 
@@ -745,8 +765,8 @@ mod tests {
             board.castling_rights & Board::BLACK_QUEEN_SIDE_CASTLING_RIGHT
         );
 
-        board.move_piece(&Move::dummy_from_to(Squares::A3, Squares::A4));
-        board.move_piece(&Move::dummy_from_to(Squares::H8, Squares::G8));
+        board.move_piece(&mut Move::dummy_from_to(Squares::A3, Squares::A4));
+        board.move_piece(&mut Move::dummy_from_to(Squares::H8, Squares::G8));
 
         board.display();
 
@@ -762,22 +782,22 @@ mod tests {
     fn test_en_passant_move() {
         let mut board = Board::new();
 
-        board.move_piece(&Move::dummy_from_to(Squares::D2, Squares::D4));
-        board.move_piece(&Move::dummy_from_to(Squares::E7, Squares::E5));
-        board.move_piece(&Move::dummy_from_to(Squares::D4, Squares::D5));
+        board.move_piece(&mut Move::dummy_from_to(Squares::D2, Squares::D4));
+        board.move_piece(&mut Move::dummy_from_to(Squares::E7, Squares::E5));
+        board.move_piece(&mut Move::dummy_from_to(Squares::D4, Squares::D5));
 
         let mut _move = Move::dummy_with_flags(DOUBLE_PAWN_PUSH, Squares::C7, Squares::C5);
 
         _move.set_en_passant_bb_position(BBPositions::C6);
         _move.set_en_passant_bb_piece_square(BBPositions::C5);
 
-        board.move_piece(&_move);
+        board.move_piece(&mut _move);
 
         assert_eq!(PieceType::Pawn, board.get_piece_type(Squares::C5));
 
         board.display();
 
-        board.move_piece(&Move::dummy_with_flags(
+        board.move_piece(&mut Move::dummy_with_flags(
             EN_PASSANT,
             Squares::D5,
             Squares::C6,
@@ -830,7 +850,7 @@ mod tests {
         let from = BBPositions::A2;
         let to = BBPositions::A4;
 
-        board.move_piece(&Move::dummy_from_to(Squares::A2, Squares::A4));
+        board.move_piece(&mut Move::dummy_from_to(Squares::A2, Squares::A4));
 
         assert_eq!(
             board.bitboards[PAWNS_IDX] & to,
@@ -852,7 +872,7 @@ mod tests {
 
         board.place_piece(Color::White, PieceType::Pawn, from);
 
-        board.move_piece(&Move::dummy_with_flags(QUEEN_PROMOTION, 55, 63));
+        board.move_piece(&mut Move::dummy_with_flags(QUEEN_PROMOTION, 55, 63));
 
         assert_eq!(
             board.bitboards[PAWNS_IDX] & to,
@@ -872,7 +892,7 @@ mod tests {
 
         board.display();
 
-        board.move_piece(&Move::dummy_from_to(8, 16));
+        board.move_piece(&mut Move::dummy_from_to(8, 16));
 
         println!("After moving white pawn from a2 to a3:");
 

--- a/ai-engine/src/game_bit_board/move_generator/attack_data.rs
+++ b/ai-engine/src/game_bit_board/move_generator/attack_data.rs
@@ -1,0 +1,361 @@
+use crate::game_bit_board::{board::Board, enums::{Color, PieceType}, move_generator::utils::print_board, positions::{same_anti_diagonal, same_diagonal, same_file, same_rank}, utils::bitwise_utils::{east_one, get_direction_to_square, no_ea_one, no_we_one, north_one, pop_lsb, to_bitboard_position, west_one}};
+
+use super::{contants::{BLACK_PAWN_ATTACKS, KNIGHT_MOVES, WHITE_PAWN_ATTACKS}, move_generator::MoveGenerator, utils::get_king_relevant_squares_related_to_enemy_pawns};
+
+pub struct AttackData {
+    pub attack_bb: u64,
+    pub defenders_bb: u64,
+    pub friendly_pins_moves_bbs: [u64; 64],
+    pub in_check: bool,
+    pub in_double_check: bool,
+    pub king_allowed_squares: u64,
+    pub king_bb_position: u64,
+    pub king_square: usize,
+    pub side_to_move: Color
+}
+
+impl AttackData {
+    pub fn new() -> Self {
+        Self {
+            attack_bb: 0,
+            defenders_bb: 0,
+            friendly_pins_moves_bbs: [0; 64],
+            in_check: false,
+            in_double_check: false,
+            king_allowed_squares: 0,
+            king_bb_position: 0,
+            king_square: 0,
+            side_to_move: Color::White
+        }
+    }
+
+    fn init(&mut self, board: &mut Board) {
+        self.attack_bb = 0;
+        self.defenders_bb = 0;
+        self.friendly_pins_moves_bbs = [0; 64];
+        self.in_check = false;
+        self.in_double_check = false;
+        self.king_allowed_squares = u64::MAX;
+
+        self.side_to_move = board.get_side_to_move();
+        self.king_bb_position = board.get_piece_positions(self.side_to_move, PieceType::King);
+        self.king_square = pop_lsb(&mut self.king_bb_position.clone()) as usize;
+    }
+
+    pub fn calculate_attack_data(&mut self, board: &mut Board, move_generator: &MoveGenerator) {
+        self.init(board);
+
+        self.check_sliding_attacks(
+            board, PieceType::Rook, move_generator
+        );
+
+        self.check_sliding_attacks(
+            board, PieceType::Bishop, move_generator
+        );
+
+        self.check_sliding_attacks(
+            board, PieceType::Queen, move_generator
+        );
+
+        self.handle_knight_checks(board);
+
+        self.handle_pawn_checks(board);
+
+        if self.in_double_check {
+            self.defenders_bb = 0;
+        }
+        else if self.defenders_bb == 0 && self.attack_bb == 0 {
+            self.defenders_bb = u64::MAX;
+        }
+
+        if self.attack_bb == 0 {
+            self.attack_bb = u64::MAX;
+        }
+
+        if self.defenders_bb != 0 {
+            println!("\nPush bb");
+
+            print_board(Color::White, self.king_square as u64, PieceType::King, self.defenders_bb);
+        }
+
+        println!("\nAttack bb");
+
+        print_board(Color::White, self.king_square as u64, PieceType::King, self.attack_bb);
+
+        println!("\nKing allowed squares");
+
+        print_board(Color::White, self.king_square as u64, PieceType::King, self.king_allowed_squares);
+
+        // println!("\nOpponent pins");
+
+        // print_board(Color::White, u64::MAX, PieceType::Empty, self.opponent_pin_bb_pos);
+
+        // self.friendly_pins_moves_bbs.iter().enumerate().for_each(|(i, bb)| {
+        //     if *bb != u64::MAX {
+        //         println!("\nFriendly pin at {}", Squares::to_string(i));
+
+        //         print_board(Color::White, i as u64, board.get_piece_type(i), *bb);
+        //     }
+        // });
+
+        // println!("In Check: {}", self.in_check);
+
+        // println!("In Double Check: {}", self.in_double_check);
+
+        // (defenders_bb, in_check, double_check)
+    }
+
+    fn handle_knight_checks(&mut self, board: &mut Board) {
+        let possible_attackers = KNIGHT_MOVES[self.king_square];
+
+        let opponent_knights = board.get_piece_positions(self.side_to_move.opponent(), PieceType::Knight);
+
+        let mut attackers = opponent_knights & possible_attackers;
+
+        if attackers == 0 {
+            return;
+        }
+
+        self.in_double_check = self.in_check;
+        self.in_check = true;
+
+        while attackers != 0 {
+            let attacker_square = pop_lsb(&mut attackers);
+
+            self.attack_bb |= to_bitboard_position(attacker_square as u64);
+        }
+    }
+
+    fn handle_pawn_checks(&mut self, board: &mut Board) {
+        let pawn_attacks = if self.side_to_move.is_white() {
+            BLACK_PAWN_ATTACKS
+        } else {
+            WHITE_PAWN_ATTACKS
+        };
+
+        let relevant_squares = get_king_relevant_squares_related_to_enemy_pawns(self.king_bb_position);
+
+        let opponent_pawns = board.get_piece_positions(self.side_to_move.opponent(), PieceType::Pawn);
+
+        let mut possible_attackers = opponent_pawns & relevant_squares;
+
+        if possible_attackers == 0 {
+            return;
+        }
+
+        while possible_attackers != 0 {
+            let attacker_square = pop_lsb(&mut possible_attackers) as usize;
+
+            let pawn_attacks = pawn_attacks[attacker_square];
+
+            if pawn_attacks & self.king_bb_position != 0 {
+                self.in_double_check = self.in_check;
+                self.in_check = true;
+
+                self.attack_bb |= to_bitboard_position(attacker_square as u64);
+            }
+
+            self.king_allowed_squares &= !pawn_attacks;
+        }
+    }
+
+    fn check_sliding_attacks(
+        &mut self, board: &mut Board, piece_type: PieceType, move_generator: &MoveGenerator
+    ) {
+        if self.in_double_check {
+            return;
+        }
+
+        let opponent = self.side_to_move.opponent();
+
+        let mut opponent_pieces = board.get_piece_positions(opponent, piece_type);
+
+        while opponent_pieces != 0 {
+            if self.in_double_check {
+                break;
+            }
+
+            let square = pop_lsb(&mut opponent_pieces) as usize;
+
+            let mut attacks = 0;
+
+            let same_orthogonal_ray = same_rank(square, self.king_square) ||
+                same_file(square, self.king_square);
+
+            let same_diagonal_ray = same_diagonal(square, self.king_square) ||
+                same_anti_diagonal(square, self.king_square);
+
+            if piece_type == PieceType::Queen && (same_orthogonal_ray || same_diagonal_ray) {
+                attacks |= move_generator.get_orthogonal_attacks(board, opponent, square);
+                attacks |= move_generator.get_diagonal_attacks(board, opponent, square);
+            }
+            else if piece_type == PieceType::Rook && same_orthogonal_ray {
+                attacks |= move_generator.get_orthogonal_attacks(board, opponent, square);
+            } else if piece_type == PieceType::Bishop && same_diagonal_ray {
+                attacks |= move_generator.get_diagonal_attacks(board, opponent, square);
+            } else {
+                continue;
+            }
+
+            if attacks & self.king_bb_position != 0 {
+                self.handle_sliding_check(square);
+            } else {
+                self.handle_pins(board, square, self.king_square);
+            }
+        }
+    }
+
+    fn handle_sliding_check(&mut self, square: usize) {
+        self.attack_bb |= 1 << square;
+        self.in_double_check = self.in_check;
+        self.in_check = true;
+
+        let direction = get_direction_to_square(square, self.king_square);
+        let mut path_to_king = direction(1 << square);
+        let mut current_pos = path_to_king;
+
+        while current_pos & self.king_bb_position == 0 {
+            path_to_king |= current_pos;
+            current_pos = direction(current_pos);
+        }
+
+        current_pos = direction(current_pos);
+
+        while current_pos != 0 {
+            self.king_allowed_squares &= !current_pos;
+
+            current_pos = direction(current_pos);
+        }
+
+        self.defenders_bb |= path_to_king;
+    }
+
+    fn handle_pins(&mut self, board: &mut Board, square: usize, king_square: usize) {
+        let direction_fn = get_direction_to_square(square, king_square);
+
+        let attacker_bb_pos = 1 << square;
+
+        let king_bb_pos = 1 << king_square;
+
+        let mut path_to_king = attacker_bb_pos;
+        let mut current_pos = direction_fn(path_to_king);
+
+        let side_to_move = board.get_side_to_move();
+
+        let mut friendly_pin_bb_pos = 0;
+        let mut opponent_pin_bb_pos = 0;
+        while current_pos != 0 {
+            if king_bb_pos == current_pos {
+                break;
+            }
+
+            let piece_type = board.get_piece_type_by_bb_pos(current_pos);
+
+            path_to_king |= current_pos;
+            current_pos = direction_fn(current_pos);
+
+            if piece_type == PieceType::Empty {
+                continue;
+            }
+
+            let piece_color = board.get_piece_color_by_bb_pos(current_pos);
+
+            if piece_color == side_to_move {
+                if friendly_pin_bb_pos != 0 || opponent_pin_bb_pos != 0 {
+                    return;
+                }
+
+                friendly_pin_bb_pos = current_pos;
+            } else {
+                if friendly_pin_bb_pos != 0 || opponent_pin_bb_pos != 0 {
+                    return;
+                }
+
+                opponent_pin_bb_pos = current_pos;
+            }
+        }
+
+        if friendly_pin_bb_pos != 0 {
+            self.friendly_pins_moves_bbs[pop_lsb(&mut friendly_pin_bb_pos) as usize] = path_to_king;
+            // self.defenders_bb |= path_to_king;
+        }
+        // else if opponent_pin_bb_pos != 0 {
+        //     self.opponent_pin_bb_pos |= opponent_pin_bb_pos;
+        // }
+    }
+}
+
+#[cfg(test)]
+mod attack_data_tests {
+    use std::sync::Mutex;
+
+    use once_cell::sync::Lazy;
+
+    use crate::game_bit_board::{board::Board, move_generator::move_generator::MoveGenerator, positions::Squares};
+
+    use super::AttackData;
+
+    static MOVE_GENERATOR: Lazy<Mutex<MoveGenerator>> = Lazy::new(|| Mutex::new(MoveGenerator::new()));
+
+    #[test]
+    fn test_pawn_check() {
+        let move_generator = MOVE_GENERATOR.lock().unwrap();
+
+        let mut attack_data = AttackData::new();
+
+        let mut board = Board::from_fen("8/8/2p3p1/3pp3/4Kpp1/8/8/8 w - - 0 1");
+
+        board.display();
+
+        attack_data.calculate_attack_data(&mut board, &move_generator);
+
+        assert_eq!(0xFFFFFF55C30FFFFF, attack_data.king_allowed_squares);
+        assert_eq!(0x0000000800000000, attack_data.attack_bb);
+
+        // Since there is no way to block a pawn check, push bb is empty
+        assert_eq!(0x0000000000000000, attack_data.defenders_bb);
+    }
+
+    #[test]
+    fn test_in_double_check() {
+        let move_generator = MOVE_GENERATOR.lock().unwrap();
+
+        let mut attack_data = AttackData::new();
+
+        let mut board = Board::from_fen("rnbqkbnr/pp3ppp/2pN4/3p4/8/5p2/PPPPQPPP/R1B1KB1R b KQkq - 1 1");
+
+        board.display();
+
+        attack_data.calculate_attack_data(&mut board, &move_generator);
+
+        // Assert double check from queen and knight
+        assert_eq!(true, attack_data.in_check);
+        assert_eq!(true, attack_data.in_double_check);
+        assert_eq!(0x0000080000001000, attack_data.attack_bb);
+        assert_eq!(0, attack_data.defenders_bb);
+
+        board = Board::from_fen("rnbqkbnr/pp3ppp/3N4/2p5/B7/3Ppp2/PPP1QPPP/R1B1K2R b KQkq - 0 1");
+
+        board.display();
+
+        attack_data.calculate_attack_data(&mut board, &move_generator);
+
+        // Assert double check from bishop and knight
+        assert_eq!(true, attack_data.in_check);
+        assert_eq!(true, attack_data.in_double_check);
+        assert_eq!(0x0000080001000000, attack_data.attack_bb);
+        assert_eq!(0, attack_data.defenders_bb);
+
+        board = Board::from_fen("rnbqkbnr/pp3ppp/2B5/2p2N2/3p4/3PRp2/PPPQ1PPP/R1B1K3 b Qkq - 0 1");
+
+        board.display();
+
+        attack_data.calculate_attack_data(&mut board, &move_generator);
+
+        // Assert double check from bishop and rook
+        assert_eq!(true, attack_data.in_check);
+        assert_eq!(true, attack_data.in_double_check);
+        assert_eq!(0x0000040000100000, attack_data.attack_bb);
+        assert_eq!(0, attack_data.defenders_bb);
+    }
+}

--- a/ai-engine/src/game_bit_board/move_generator/attack_data.rs
+++ b/ai-engine/src/game_bit_board/move_generator/attack_data.rs
@@ -1,12 +1,8 @@
 use crate::game_bit_board::{
-    board::Board,
-    enums::{Color, PieceType},
-    move_generator::utils::print_board,
-    positions::{same_anti_diagonal, same_diagonal, same_file, same_rank, Squares},
-    utils::bitwise_utils::{
+    board::Board, enums::{Color, PieceType}, move_generator::utils::print_board, positions::{same_anti_diagonal, same_diagonal, same_file, same_rank, Squares}, utils::bitwise_utils::{
         get_direction_to_square, pop_lsb,
         to_bitboard_position
-    },
+    }
 };
 
 use super::{
@@ -74,6 +70,12 @@ impl AttackData {
             self.defenders_bb = u64::MAX;
         }
 
+        // if self.in_check && self.defenders_bb == 0
+        //     && board.get_en_passant() != 0 {
+
+        //     self.attack_bb |= board.get_en_passant();
+        // }
+
         if self.attack_bb == 0 {
             self.attack_bb = u64::MAX;
         }
@@ -119,11 +121,6 @@ impl AttackData {
         //     );
         // }
 
-        // println!("\nOpponent pins");
-
-        // print_board(Color::White, u64::MAX, PieceType::Empty,
-        // self.opponent_pin_bb_pos);
-
         // self.friendly_pins_moves_bbs.iter().enumerate().for_each(|(i, bb)| {
         //     if *bb != u64::MAX {
         //         println!("\nFriendly pin at {}", Squares::to_string(i));
@@ -131,6 +128,11 @@ impl AttackData {
         //         print_board(Color::White, i as u64, board.get_piece_type(i), *bb);
         //     }
         // });
+
+        // println!("\nOpponent pins");
+
+        // print_board(Color::White, u64::MAX, PieceType::Empty,
+        // self.opponent_pin_bb_pos);
 
         // (defenders_bb, in_check, double_check)
     }
@@ -195,9 +197,9 @@ impl AttackData {
     fn check_sliding_attacks(
         &mut self, board: &mut Board, piece_type: PieceType, move_generator: &MoveGenerator,
     ) {
-        if self.in_double_check {
-            return;
-        }
+        // if self.in_double_check {
+        //     return;
+        // }
 
         let opponent = self.side_to_move.opponent();
 
@@ -205,9 +207,9 @@ impl AttackData {
         let opponent_pieces_bb = board.get_player_pieces_positions(opponent);
 
         while opponent_pieces != 0 {
-            if self.in_double_check {
-                break;
-            }
+            // if self.in_double_check {
+            //     break;
+            // }
 
             let square = pop_lsb(&mut opponent_pieces) as usize;
 

--- a/ai-engine/src/game_bit_board/move_generator/attack_data.rs
+++ b/ai-engine/src/game_bit_board/move_generator/attack_data.rs
@@ -1,6 +1,19 @@
-use crate::game_bit_board::{board::Board, enums::{Color, PieceType}, move_generator::utils::print_board, positions::{same_anti_diagonal, same_diagonal, same_file, same_rank}, utils::bitwise_utils::{east_one, get_direction_to_square, no_ea_one, no_we_one, north_one, pop_lsb, to_bitboard_position, west_one}};
+use crate::game_bit_board::{
+    board::Board,
+    enums::{Color, PieceType},
+    move_generator::utils::print_board,
+    positions::{same_anti_diagonal, same_diagonal, same_file, same_rank},
+    utils::bitwise_utils::{
+        east_one, get_direction_to_square, no_ea_one, no_we_one, north_one, pop_lsb,
+        to_bitboard_position, west_one,
+    },
+};
 
-use super::{contants::{BLACK_PAWN_ATTACKS, KNIGHT_MOVES, WHITE_PAWN_ATTACKS}, move_generator::MoveGenerator, utils::get_king_relevant_squares_related_to_enemy_pawns};
+use super::{
+    contants::{BLACK_PAWN_ATTACKS, KNIGHT_MOVES, WHITE_PAWN_ATTACKS},
+    move_generator::MoveGenerator,
+    utils::get_king_relevant_squares_related_to_enemy_pawns,
+};
 
 pub struct AttackData {
     pub attack_bb: u64,
@@ -11,7 +24,7 @@ pub struct AttackData {
     pub king_allowed_squares: u64,
     pub king_bb_position: u64,
     pub king_square: usize,
-    pub side_to_move: Color
+    pub side_to_move: Color,
 }
 
 impl AttackData {
@@ -25,7 +38,7 @@ impl AttackData {
             king_allowed_squares: 0,
             king_bb_position: 0,
             king_square: 0,
-            side_to_move: Color::White
+            side_to_move: Color::White,
         }
     }
 
@@ -45,17 +58,11 @@ impl AttackData {
     pub fn calculate_attack_data(&mut self, board: &mut Board, move_generator: &MoveGenerator) {
         self.init(board);
 
-        self.check_sliding_attacks(
-            board, PieceType::Rook, move_generator
-        );
+        self.check_sliding_attacks(board, PieceType::Rook, move_generator);
 
-        self.check_sliding_attacks(
-            board, PieceType::Bishop, move_generator
-        );
+        self.check_sliding_attacks(board, PieceType::Bishop, move_generator);
 
-        self.check_sliding_attacks(
-            board, PieceType::Queen, move_generator
-        );
+        self.check_sliding_attacks(board, PieceType::Queen, move_generator);
 
         self.handle_knight_checks(board);
 
@@ -63,8 +70,7 @@ impl AttackData {
 
         if self.in_double_check {
             self.defenders_bb = 0;
-        }
-        else if self.defenders_bb == 0 && self.attack_bb == 0 {
+        } else if self.defenders_bb == 0 && self.attack_bb == 0 {
             self.defenders_bb = u64::MAX;
         }
 
@@ -75,27 +81,43 @@ impl AttackData {
         if self.defenders_bb != 0 {
             println!("\nPush bb");
 
-            print_board(Color::White, self.king_square as u64, PieceType::King, self.defenders_bb);
+            print_board(
+                Color::White,
+                self.king_square as u64,
+                PieceType::King,
+                self.defenders_bb,
+            );
         }
 
         println!("\nAttack bb");
 
-        print_board(Color::White, self.king_square as u64, PieceType::King, self.attack_bb);
+        print_board(
+            Color::White,
+            self.king_square as u64,
+            PieceType::King,
+            self.attack_bb,
+        );
 
         println!("\nKing allowed squares");
 
-        print_board(Color::White, self.king_square as u64, PieceType::King, self.king_allowed_squares);
+        print_board(
+            Color::White,
+            self.king_square as u64,
+            PieceType::King,
+            self.king_allowed_squares,
+        );
 
         // println!("\nOpponent pins");
 
-        // print_board(Color::White, u64::MAX, PieceType::Empty, self.opponent_pin_bb_pos);
+        // print_board(Color::White, u64::MAX, PieceType::Empty,
+        // self.opponent_pin_bb_pos);
 
         // self.friendly_pins_moves_bbs.iter().enumerate().for_each(|(i, bb)| {
         //     if *bb != u64::MAX {
         //         println!("\nFriendly pin at {}", Squares::to_string(i));
 
-        //         print_board(Color::White, i as u64, board.get_piece_type(i), *bb);
-        //     }
+        //         print_board(Color::White, i as u64, board.get_piece_type(i),
+        // *bb);     }
         // });
 
         // println!("In Check: {}", self.in_check);
@@ -108,7 +130,8 @@ impl AttackData {
     fn handle_knight_checks(&mut self, board: &mut Board) {
         let possible_attackers = KNIGHT_MOVES[self.king_square];
 
-        let opponent_knights = board.get_piece_positions(self.side_to_move.opponent(), PieceType::Knight);
+        let opponent_knights =
+            board.get_piece_positions(self.side_to_move.opponent(), PieceType::Knight);
 
         let mut attackers = opponent_knights & possible_attackers;
 
@@ -133,9 +156,11 @@ impl AttackData {
             WHITE_PAWN_ATTACKS
         };
 
-        let relevant_squares = get_king_relevant_squares_related_to_enemy_pawns(self.king_bb_position);
+        let relevant_squares =
+            get_king_relevant_squares_related_to_enemy_pawns(self.king_bb_position);
 
-        let opponent_pawns = board.get_piece_positions(self.side_to_move.opponent(), PieceType::Pawn);
+        let opponent_pawns =
+            board.get_piece_positions(self.side_to_move.opponent(), PieceType::Pawn);
 
         let mut possible_attackers = opponent_pawns & relevant_squares;
 
@@ -160,7 +185,7 @@ impl AttackData {
     }
 
     fn check_sliding_attacks(
-        &mut self, board: &mut Board, piece_type: PieceType, move_generator: &MoveGenerator
+        &mut self, board: &mut Board, piece_type: PieceType, move_generator: &MoveGenerator,
     ) {
         if self.in_double_check {
             return;
@@ -179,17 +204,16 @@ impl AttackData {
 
             let mut attacks = 0;
 
-            let same_orthogonal_ray = same_rank(square, self.king_square) ||
-                same_file(square, self.king_square);
+            let same_orthogonal_ray =
+                same_rank(square, self.king_square) || same_file(square, self.king_square);
 
-            let same_diagonal_ray = same_diagonal(square, self.king_square) ||
-                same_anti_diagonal(square, self.king_square);
+            let same_diagonal_ray = same_diagonal(square, self.king_square)
+                || same_anti_diagonal(square, self.king_square);
 
             if piece_type == PieceType::Queen && (same_orthogonal_ray || same_diagonal_ray) {
                 attacks |= move_generator.get_orthogonal_attacks(board, opponent, square);
                 attacks |= move_generator.get_diagonal_attacks(board, opponent, square);
-            }
-            else if piece_type == PieceType::Rook && same_orthogonal_ray {
+            } else if piece_type == PieceType::Rook && same_orthogonal_ray {
                 attacks |= move_generator.get_orthogonal_attacks(board, opponent, square);
             } else if piece_type == PieceType::Bishop && same_diagonal_ray {
                 attacks |= move_generator.get_diagonal_attacks(board, opponent, square);
@@ -291,11 +315,14 @@ mod attack_data_tests {
 
     use once_cell::sync::Lazy;
 
-    use crate::game_bit_board::{board::Board, move_generator::move_generator::MoveGenerator, positions::Squares};
+    use crate::game_bit_board::{
+        board::Board, move_generator::move_generator::MoveGenerator, positions::Squares,
+    };
 
     use super::AttackData;
 
-    static MOVE_GENERATOR: Lazy<Mutex<MoveGenerator>> = Lazy::new(|| Mutex::new(MoveGenerator::new()));
+    static MOVE_GENERATOR: Lazy<Mutex<MoveGenerator>> =
+        Lazy::new(|| Mutex::new(MoveGenerator::new()));
 
     #[test]
     fn test_pawn_check() {
@@ -322,7 +349,8 @@ mod attack_data_tests {
 
         let mut attack_data = AttackData::new();
 
-        let mut board = Board::from_fen("rnbqkbnr/pp3ppp/2pN4/3p4/8/5p2/PPPPQPPP/R1B1KB1R b KQkq - 1 1");
+        let mut board =
+            Board::from_fen("rnbqkbnr/pp3ppp/2pN4/3p4/8/5p2/PPPPQPPP/R1B1KB1R b KQkq - 1 1");
 
         board.display();
 

--- a/ai-engine/src/game_bit_board/move_generator/attack_data.rs
+++ b/ai-engine/src/game_bit_board/move_generator/attack_data.rs
@@ -1,8 +1,9 @@
 use crate::game_bit_board::{
-    board::Board, enums::{Color, PieceType}, move_generator::utils::print_board, positions::{same_anti_diagonal, same_diagonal, same_file, same_rank, Squares}, utils::bitwise_utils::{
-        get_direction_to_square, pop_lsb,
-        to_bitboard_position
-    }
+    board::Board,
+    enums::{Color, PieceType},
+    move_generator::utils::print_board,
+    positions::{same_anti_diagonal, same_diagonal, same_file, same_rank, Squares},
+    utils::bitwise_utils::{get_direction_to_square, pop_lsb, to_bitboard_position},
 };
 
 use super::{
@@ -125,8 +126,8 @@ impl AttackData {
         //     if *bb != u64::MAX {
         //         println!("\nFriendly pin at {}", Squares::to_string(i));
 
-        //         print_board(Color::White, i as u64, board.get_piece_type(i), *bb);
-        //     }
+        //         print_board(Color::White, i as u64, board.get_piece_type(i),
+        // *bb);     }
         // });
 
         // println!("\nOpponent pins");
@@ -224,22 +225,42 @@ impl AttackData {
             // println!("There is a {} at {}", piece_type, Squares::to_string(square));
 
             if piece_type == PieceType::Queen {
-                attacks |= move_generator.get_orthogonal_attacks(board, opponent, square, &opponent_pieces_bb);
-                attacks |= move_generator.get_diagonal_attacks(board, opponent, square, &opponent_pieces_bb);
+                attacks |= move_generator.get_orthogonal_attacks(
+                    board,
+                    opponent,
+                    square,
+                    &opponent_pieces_bb,
+                );
+                attacks |= move_generator.get_diagonal_attacks(
+                    board,
+                    opponent,
+                    square,
+                    &opponent_pieces_bb,
+                );
                 self.king_allowed_squares &= !attacks;
 
                 if !same_orthogonal_ray && !same_diagonal_ray {
                     continue;
                 }
             } else if piece_type == PieceType::Rook {
-                attacks |= move_generator.get_orthogonal_attacks(board, opponent, square, &opponent_pieces_bb);
+                attacks |= move_generator.get_orthogonal_attacks(
+                    board,
+                    opponent,
+                    square,
+                    &opponent_pieces_bb,
+                );
                 self.king_allowed_squares &= !attacks;
 
                 if !same_orthogonal_ray {
                     continue;
                 }
             } else if piece_type == PieceType::Bishop {
-                attacks |= move_generator.get_diagonal_attacks(board, opponent, square, &opponent_pieces_bb);
+                attacks |= move_generator.get_diagonal_attacks(
+                    board,
+                    opponent,
+                    square,
+                    &opponent_pieces_bb,
+                );
                 self.king_allowed_squares &= !attacks;
 
                 if !same_diagonal_ray {
@@ -256,7 +277,8 @@ impl AttackData {
                 //     Squares::to_string(square), Squares::to_string(self.king_square));
                 self.handle_sliding_check(square);
             } else {
-                // println!("Will handle pins for possible pinner at {}", Squares::to_string(square));
+                // println!("Will handle pins for possible pinner at {}",
+                // Squares::to_string(square));
                 self.handle_pins(board, square);
             }
         }
@@ -349,9 +371,7 @@ mod attack_data_tests {
 
     use once_cell::sync::Lazy;
 
-    use crate::game_bit_board::{
-        board::Board, move_generator::move_generator::MoveGenerator
-    };
+    use crate::game_bit_board::{board::Board, move_generator::move_generator::MoveGenerator};
 
     use super::AttackData;
 

--- a/ai-engine/src/game_bit_board/move_generator/mod.rs
+++ b/ai-engine/src/game_bit_board/move_generator/mod.rs
@@ -1,3 +1,4 @@
 mod contants;
 pub mod move_generator;
 mod raw_move_generator;
+mod utils;

--- a/ai-engine/src/game_bit_board/move_generator/mod.rs
+++ b/ai-engine/src/game_bit_board/move_generator/mod.rs
@@ -1,5 +1,5 @@
+mod attack_data;
 mod contants;
 pub mod move_generator;
 mod raw_move_generator;
 mod utils;
-mod attack_data;

--- a/ai-engine/src/game_bit_board/move_generator/mod.rs
+++ b/ai-engine/src/game_bit_board/move_generator/mod.rs
@@ -2,3 +2,4 @@ mod contants;
 pub mod move_generator;
 mod raw_move_generator;
 mod utils;
+mod attack_data;

--- a/ai-engine/src/game_bit_board/move_generator/move_generator.rs
+++ b/ai-engine/src/game_bit_board/move_generator/move_generator.rs
@@ -155,7 +155,8 @@ impl MoveGenerator {
         moves.retain(|_move| !opponent_piece_squares.contains(&_move.get_from()));
 
         if attack_data.in_double_check {
-            // println!("Is in double check, removing invalid moves. King is at {}", Squares::to_string(friendly_king_square));
+            // println!("Is in double check, removing invalid moves. King is at {}",
+            // Squares::to_string(friendly_king_square));
             moves.retain(|_move| _move.get_from() == friendly_king_square);
         }
 
@@ -175,9 +176,11 @@ impl MoveGenerator {
     ) {
         // if square == Squares::F3 {
         //     println!("DEBUG::::");
-        //     print_board(color, square as u64, piece_type, self.get_diagonal_attacks(board, color, square));
-        //     print_board(color, square as u64, piece_type, attack_data.friendly_pins_moves_bbs[square]);
-        //     print_board(color, square as u64, piece_type, attack_data.defenders_bb | attack_data.attack_bb);
+        //     print_board(color, square as u64, piece_type,
+        // self.get_diagonal_attacks(board, color, square));
+        //     print_board(color, square as u64, piece_type,
+        // attack_data.friendly_pins_moves_bbs[square]);     print_board(color,
+        // square as u64, piece_type, attack_data.defenders_bb | attack_data.attack_bb);
         // }
 
         let friendly_pieces_bb = board.get_player_pieces_positions(color);
@@ -191,7 +194,6 @@ impl MoveGenerator {
             & attack_data.friendly_pins_moves_bbs[square]
             & (attack_data.defenders_bb | attack_data.attack_bb);
 
-
         create_moves(
             attacks,
             board.get_player_pieces_positions(color.opponent()),
@@ -202,7 +204,9 @@ impl MoveGenerator {
         );
     }
 
-    pub fn get_diagonal_attacks(&self, board: &Board, color: Color, square: usize, friendly_pieces_bb: &u64) -> u64 {
+    pub fn get_diagonal_attacks(
+        &self, board: &Board, color: Color, square: usize, friendly_pieces_bb: &u64,
+    ) -> u64 {
         let opponent_pieces_bb = board.get_player_pieces_positions(color.opponent());
         let occupied_relevant_squares =
             (friendly_pieces_bb | opponent_pieces_bb) & BISHOP_RELEVANT_SQUARES[square];
@@ -230,7 +234,6 @@ impl MoveGenerator {
             & attack_data.friendly_pins_moves_bbs[square]
             & (attack_data.defenders_bb | attack_data.attack_bb);
 
-
         create_moves(
             attacks,
             board.get_player_pieces_positions(color.opponent()),
@@ -241,7 +244,9 @@ impl MoveGenerator {
         );
     }
 
-    pub fn get_orthogonal_attacks(&self, board: &Board, color: Color, square: usize, friendly_pieces_bb: &u64) -> u64 {
+    pub fn get_orthogonal_attacks(
+        &self, board: &Board, color: Color, square: usize, friendly_pieces_bb: &u64,
+    ) -> u64 {
         let opponent_pieces_bb = board.get_player_pieces_positions(color.opponent());
         let occupied_relevant_squares =
             (friendly_pieces_bb | opponent_pieces_bb) & ROOK_RELEVANT_SQUARES[square];
@@ -315,7 +320,9 @@ impl MoveGenerator {
             PieceType::King,
         );
 
-        if attack_data.in_check || (to_bitboard_position(square as u64) & opponent_attacks != 0 && attacks == 0) {
+        if attack_data.in_check
+            || (to_bitboard_position(square as u64) & opponent_attacks != 0 && attacks == 0)
+        {
             return;
         }
 
@@ -412,10 +419,10 @@ impl MoveGenerator {
 
         *attacked_squares |= raw_attacks;
 
-        let mut attacks = (raw_attacks
-            & !friendly_pieces_bb)
+        let mut attacks = (raw_attacks & !friendly_pieces_bb)
             & attack_data.friendly_pins_moves_bbs[square]
-            & (attack_data.defenders_bb | attack_data.attack_bb) & opponent_pieces_bb;
+            & (attack_data.defenders_bb | attack_data.attack_bb)
+            & opponent_pieces_bb;
 
         while attacks != 0 {
             let target_square = pop_lsb(&mut attacks);
@@ -484,7 +491,9 @@ impl MoveGenerator {
                 & attack_data.friendly_pins_moves_bbs[square];
 
             // King is under attack and en passant captures the attacking pawn
-            if attack_data.defenders_bb == 0 && (attack_data.attack_bb & board.get_en_passant_square() != 0) {
+            if attack_data.defenders_bb == 0
+                && (attack_data.attack_bb & board.get_en_passant_square() != 0)
+            {
                 attacks &= board.get_en_passant();
             } else {
                 attacks &= attack_data.defenders_bb | attack_data.attack_bb
@@ -492,9 +501,8 @@ impl MoveGenerator {
 
             // A pawn will never be able to have more than one
             // en passant move at the same time
-            while attacks != 0
-                && !is_en_passant_discovered_check(color, attack_data, square, board) {
-
+            while attacks != 0 && !is_en_passant_discovered_check(color, attack_data, square, board)
+            {
                 let target_square = pop_lsb(&mut attacks);
 
                 moves.push(Move::with_flags(
@@ -548,7 +556,9 @@ impl MoveGenerator {
     }
 }
 
-fn is_en_passant_discovered_check(color: Color, attack_data: &AttackData, square: usize, board: &Board) -> bool {
+fn is_en_passant_discovered_check(
+    color: Color, attack_data: &AttackData, square: usize, board: &Board,
+) -> bool {
     if color != attack_data.side_to_move || !same_rank(square, attack_data.king_square) {
         return false;
     }
@@ -557,13 +567,9 @@ fn is_en_passant_discovered_check(color: Color, attack_data: &AttackData, square
 
     let opponent = attack_data.side_to_move.opponent();
 
-    let opponent_queens = board.get_piece_positions(
-        opponent, PieceType::Queen)
-        & row;
+    let opponent_queens = board.get_piece_positions(opponent, PieceType::Queen) & row;
 
-    let opponent_rooks = board.get_piece_positions(
-        opponent, PieceType::Rook)
-        & row;
+    let opponent_rooks = board.get_piece_positions(opponent, PieceType::Rook) & row;
 
     if opponent_rooks == 0 && opponent_queens == 0 {
         return false;
@@ -581,8 +587,8 @@ fn is_en_passant_discovered_check(color: Color, attack_data: &AttackData, square
     if opponent_rooks != 0 {
         let closest_rook_square = get_closest_square(attack_data.king_square, opponent_rooks);
 
-        squares_between_rook_and_king = squares_between(
-            attack_data.king_square, closest_rook_square);
+        squares_between_rook_and_king =
+            squares_between(attack_data.king_square, closest_rook_square);
     }
 
     let mut squares_between_queen_and_king = 0;
@@ -590,10 +596,9 @@ fn is_en_passant_discovered_check(color: Color, attack_data: &AttackData, square
         let closest_queen_square = get_closest_square(attack_data.king_square, opponent_queens);
 
         if closest_queen_square != 0 {
-            squares_between_queen_and_king = squares_between(
-                attack_data.king_square, closest_queen_square);
+            squares_between_queen_and_king =
+                squares_between(attack_data.king_square, closest_queen_square);
         }
-
     }
 
     let squares_between_king = squares_between_rook_and_king | squares_between_queen_and_king;

--- a/ai-engine/src/game_bit_board/move_generator/move_generator.rs
+++ b/ai-engine/src/game_bit_board/move_generator/move_generator.rs
@@ -172,7 +172,17 @@ impl MoveGenerator {
         &self, board: &Board, moves: &mut Vec<Move>, square: usize, color: Color,
         attacked_squares: &mut u64, piece_type: PieceType, attack_data: &AttackData,
     ) {
-        let attacks = self.get_diagonal_attacks(board, color, square)
+        // if square == Squares::F3 {
+        //     println!("DEBUG::::");
+        //     print_board(color, square as u64, piece_type, self.get_diagonal_attacks(board, color, square));
+        //     print_board(color, square as u64, piece_type, attack_data.friendly_pins_moves_bbs[square]);
+        //     print_board(color, square as u64, piece_type, attack_data.defenders_bb | attack_data.attack_bb);
+        // }
+
+        let friendly_pieces_bb = board.get_player_pieces_positions(color);
+
+        let attacks = self.get_diagonal_attacks(board, color, square, &friendly_pieces_bb)
+            & !friendly_pieces_bb
             & attack_data.friendly_pins_moves_bbs[square]
             & (attack_data.defenders_bb | attack_data.attack_bb);
 
@@ -188,8 +198,7 @@ impl MoveGenerator {
         );
     }
 
-    pub fn get_diagonal_attacks(&self, board: &Board, color: Color, square: usize) -> u64 {
-        let friendly_pieces_bb = board.get_player_pieces_positions(color);
+    pub fn get_diagonal_attacks(&self, board: &Board, color: Color, square: usize, friendly_pieces_bb: &u64) -> u64 {
         let opponent_pieces_bb = board.get_player_pieces_positions(color.opponent());
         let occupied_relevant_squares =
             (friendly_pieces_bb | opponent_pieces_bb) & BISHOP_RELEVANT_SQUARES[square];
@@ -199,14 +208,17 @@ impl MoveGenerator {
             .get(&(square as u8, occupied_relevant_squares))
             .unwrap();
 
-        (attacks & !friendly_pieces_bb)
+        attacks
     }
 
     fn get_orthogonal_moves(
         &self, board: &Board, moves: &mut Vec<Move>, square: usize, color: Color,
         attacked_squares: &mut u64, piece_type: PieceType, attack_data: &AttackData,
     ) {
-        let attacks = self.get_orthogonal_attacks(board, color, square)
+        let friendly_pieces_bb = board.get_player_pieces_positions(color);
+
+        let attacks = self.get_orthogonal_attacks(board, color, square, &friendly_pieces_bb)
+            & !friendly_pieces_bb
             & attack_data.friendly_pins_moves_bbs[square]
             & (attack_data.defenders_bb | attack_data.attack_bb);
 
@@ -222,8 +234,7 @@ impl MoveGenerator {
         );
     }
 
-    pub fn get_orthogonal_attacks(&self, board: &Board, color: Color, square: usize) -> u64 {
-        let friendly_pieces_bb = board.get_player_pieces_positions(color);
+    pub fn get_orthogonal_attacks(&self, board: &Board, color: Color, square: usize, friendly_pieces_bb: &u64) -> u64 {
         let opponent_pieces_bb = board.get_player_pieces_positions(color.opponent());
         let occupied_relevant_squares =
             (friendly_pieces_bb | opponent_pieces_bb) & ROOK_RELEVANT_SQUARES[square];
@@ -233,7 +244,7 @@ impl MoveGenerator {
             .get(&(square as u8, occupied_relevant_squares))
             .unwrap();
 
-        (attacks & !friendly_pieces_bb)
+        attacks
     }
 
     fn get_knight_moves(

--- a/ai-engine/src/game_bit_board/move_generator/move_generator.rs
+++ b/ai-engine/src/game_bit_board/move_generator/move_generator.rs
@@ -1,18 +1,25 @@
-use std::{collections::HashMap, u64, usize};
-use crate::game_bit_board::{
-    _move::{_move::Move, move_contants::*}, board::Board, enums::{Color, PieceType}, positions::Squares, utils::{
-        bitwise_utils::{east_one, north_one, pop_lsb, south_one, to_bitboard_position, west_one},
-        utils::is_pawn_in_initial_position,
-    }
-};
 use super::{
-    attack_data::AttackData, contants::{
+    attack_data::AttackData,
+    contants::{
         BISHOP_RELEVANT_SQUARES, BLACK_KING_SIDE_PATH_TO_ROOK, BLACK_PAWN_ATTACKS,
         BLACK_PAWN_MOVES, BLACK_QUEEN_SIDE_PATH_TO_ROOK, KING_MOVES, KNIGHT_MOVES,
         ROOK_RELEVANT_SQUARES, WHITE_KING_SIDE_PATH_TO_ROOK, WHITE_PAWN_ATTACKS, WHITE_PAWN_MOVES,
         WHITE_QUEEN_SIDE_PATH_TO_ROOK,
-    }, raw_move_generator::RawMoveGenerator, utils::create_moves
+    },
+    raw_move_generator::RawMoveGenerator,
+    utils::create_moves,
 };
+use crate::game_bit_board::{
+    _move::{_move::Move, move_contants::*},
+    board::Board,
+    enums::{Color, PieceType},
+    positions::Squares,
+    utils::{
+        bitwise_utils::{east_one, north_one, pop_lsb, south_one, to_bitboard_position, west_one},
+        utils::is_pawn_in_initial_position,
+    },
+};
+use std::{collections::HashMap, u64, usize};
 #[derive(Clone)]
 pub struct MoveGenerator {
     bishop_lookup_table: HashMap<(u8, u64), u64>,
@@ -28,7 +35,7 @@ impl MoveGenerator {
 
         Self {
             bishop_lookup_table,
-            rook_lookup_table
+            rook_lookup_table,
         }
     }
 
@@ -70,12 +77,44 @@ impl MoveGenerator {
             } else if piece_type == PieceType::Knight {
                 self.get_knight_moves(board, &mut moves, square, color, attacks, &attack_data);
             } else if piece_type == PieceType::Rook {
-                self.get_orthogonal_moves(board, &mut moves, square, color, attacks, PieceType::Rook, &attack_data);
+                self.get_orthogonal_moves(
+                    board,
+                    &mut moves,
+                    square,
+                    color,
+                    attacks,
+                    PieceType::Rook,
+                    &attack_data,
+                );
             } else if piece_type == PieceType::Bishop {
-                self.get_diagonal_moves(board, &mut moves, square, color, attacks, PieceType::Bishop, &attack_data);
+                self.get_diagonal_moves(
+                    board,
+                    &mut moves,
+                    square,
+                    color,
+                    attacks,
+                    PieceType::Bishop,
+                    &attack_data,
+                );
             } else if piece_type == PieceType::Queen {
-                self.get_orthogonal_moves(board, &mut moves, square, color, attacks, PieceType::Queen, &attack_data);
-                self.get_diagonal_moves(board, &mut moves, square, color, attacks, PieceType::Queen, &attack_data);
+                self.get_orthogonal_moves(
+                    board,
+                    &mut moves,
+                    square,
+                    color,
+                    attacks,
+                    PieceType::Queen,
+                    &attack_data,
+                );
+                self.get_diagonal_moves(
+                    board,
+                    &mut moves,
+                    square,
+                    color,
+                    attacks,
+                    PieceType::Queen,
+                    &attack_data,
+                );
             } else if piece_type == PieceType::King {
                 if board.get_side_to_move() == color {
                     friendly_king_square = square
@@ -97,7 +136,7 @@ impl MoveGenerator {
                 friendly_color.opponent(),
                 &friendly_attacks,
                 &mut opponent_attacks,
-                &attack_data
+                &attack_data,
             );
         }
 
@@ -109,7 +148,7 @@ impl MoveGenerator {
                 friendly_color,
                 &opponent_attacks,
                 &mut friendly_attacks,
-                &attack_data
+                &attack_data,
             );
         }
 
@@ -131,13 +170,22 @@ impl MoveGenerator {
 
     fn get_diagonal_moves(
         &self, board: &Board, moves: &mut Vec<Move>, square: usize, color: Color,
-        attacked_squares: &mut u64, piece_type: PieceType, attack_data: &AttackData
+        attacked_squares: &mut u64, piece_type: PieceType, attack_data: &AttackData,
     ) {
-        let attacks = self.get_diagonal_attacks(board, color, square)& attack_data.friendly_pins_moves_bbs[square] & (attack_data.defenders_bb | attack_data.attack_bb);
+        let attacks = self.get_diagonal_attacks(board, color, square)
+            & attack_data.friendly_pins_moves_bbs[square]
+            & (attack_data.defenders_bb | attack_data.attack_bb);
 
         *attacked_squares |= attacks;
 
-        create_moves(attacks, board.get_player_pieces_positions(color.opponent()), moves, square, color, piece_type);
+        create_moves(
+            attacks,
+            board.get_player_pieces_positions(color.opponent()),
+            moves,
+            square,
+            color,
+            piece_type,
+        );
     }
 
     pub fn get_diagonal_attacks(&self, board: &Board, color: Color, square: usize) -> u64 {
@@ -156,13 +204,22 @@ impl MoveGenerator {
 
     fn get_orthogonal_moves(
         &self, board: &Board, moves: &mut Vec<Move>, square: usize, color: Color,
-        attacked_squares: &mut u64, piece_type: PieceType, attack_data: &AttackData
+        attacked_squares: &mut u64, piece_type: PieceType, attack_data: &AttackData,
     ) {
-        let attacks = self.get_orthogonal_attacks(board, color, square)& attack_data.friendly_pins_moves_bbs[square] & (attack_data.defenders_bb | attack_data.attack_bb);
+        let attacks = self.get_orthogonal_attacks(board, color, square)
+            & attack_data.friendly_pins_moves_bbs[square]
+            & (attack_data.defenders_bb | attack_data.attack_bb);
 
         *attacked_squares |= attacks;
 
-        create_moves(attacks, board.get_player_pieces_positions(color.opponent()), moves, square, color, piece_type);
+        create_moves(
+            attacks,
+            board.get_player_pieces_positions(color.opponent()),
+            moves,
+            square,
+            color,
+            piece_type,
+        );
     }
 
     pub fn get_orthogonal_attacks(&self, board: &Board, color: Color, square: usize) -> u64 {
@@ -180,33 +237,51 @@ impl MoveGenerator {
     }
 
     fn get_knight_moves(
-        &self,board: &Board, moves: &mut Vec<Move>, square: usize, color: Color,
-        attacked_squares: &mut u64, attack_data: &AttackData
+        &self, board: &Board, moves: &mut Vec<Move>, square: usize, color: Color,
+        attacked_squares: &mut u64, attack_data: &AttackData,
     ) {
         let friendly_pieces_bb = board.get_player_pieces_positions(color);
         let opponent_pieces_bb = board.get_player_pieces_positions(color.opponent());
 
-        let attacks = (KNIGHT_MOVES[square] & !friendly_pieces_bb) & attack_data.friendly_pins_moves_bbs[square] & (attack_data.defenders_bb | attack_data.attack_bb);
+        let attacks = (KNIGHT_MOVES[square] & !friendly_pieces_bb)
+            & attack_data.friendly_pins_moves_bbs[square]
+            & (attack_data.defenders_bb | attack_data.attack_bb);
 
         *attacked_squares |= attacks;
 
-        create_moves(attacks, opponent_pieces_bb, moves, square, color, PieceType::Knight);
+        create_moves(
+            attacks,
+            opponent_pieces_bb,
+            moves,
+            square,
+            color,
+            PieceType::Knight,
+        );
     }
 
     fn get_king_moves(
-        &mut self, board: &Board, moves: &mut Vec<Move>, square: usize, color: Color, opponent_attacks: &u64,
-        attacked_squares: &mut u64, attack_data: &AttackData
+        &mut self, board: &Board, moves: &mut Vec<Move>, square: usize, color: Color,
+        opponent_attacks: &u64, attacked_squares: &mut u64, attack_data: &AttackData,
     ) {
         let friendly_pieces_bb = board.get_player_pieces_positions(color);
         let opponent_pieces_bb = board.get_player_pieces_positions(color.opponent());
         let occupied_squares = friendly_pieces_bb | opponent_pieces_bb;
 
-        // I guess I can just use & self.friendly_pins_moves_bbs[square] instead of having a king allowed squares var
-        let attacks = ((KING_MOVES[square] & !friendly_pieces_bb) & !opponent_attacks) & attack_data.king_allowed_squares;
+        // I guess I can just use & self.friendly_pins_moves_bbs[square] instead of
+        // having a king allowed squares var
+        let attacks = ((KING_MOVES[square] & !friendly_pieces_bb) & !opponent_attacks)
+            & attack_data.king_allowed_squares;
 
         *attacked_squares |= attacks;
 
-        create_moves(attacks, opponent_pieces_bb, moves, square, color, PieceType::King);
+        create_moves(
+            attacks,
+            opponent_pieces_bb,
+            moves,
+            square,
+            color,
+            PieceType::King,
+        );
 
         if to_bitboard_position(square as u64) & opponent_attacks != 0 && attacks == 0 {
             return;
@@ -295,19 +370,22 @@ impl MoveGenerator {
 
     fn get_pawn_moves(
         &self, board: &Board, moves: &mut Vec<Move>, square: usize, color: Color,
-        attacked_squares: &mut u64, attack_data: &AttackData
+        attacked_squares: &mut u64, attack_data: &AttackData,
     ) {
         // TODO: promotions
         let friendly_pieces_bb = board.get_player_pieces_positions(color);
         let opponent_pieces_bb = board.get_player_pieces_positions(color.opponent());
         let occupied_squares = friendly_pieces_bb | opponent_pieces_bb;
 
-        let raw_attacks = (MoveGenerator::look_up_pawn_attacks(color, square) & !friendly_pieces_bb) & attack_data.friendly_pins_moves_bbs[square] & (attack_data.defenders_bb | attack_data.attack_bb);
+        let raw_attacks = (MoveGenerator::look_up_pawn_attacks(color, square)
+            & !friendly_pieces_bb)
+            & attack_data.friendly_pins_moves_bbs[square]
+            & (attack_data.defenders_bb | attack_data.attack_bb);
 
         // if self.friendly_pins_moves_bbs[square] != u64::MAX {
-        //     println!("Pins moves bb is not all!! Generating for square {}", Squares::to_string(square));
-        //     print_board(color, square as u64, PieceType::Pawn, self.friendly_pins_moves_bbs[square]);
-        // }
+        //     println!("Pins moves bb is not all!! Generating for square {}",
+        // Squares::to_string(square));     print_board(color, square as u64,
+        // PieceType::Pawn, self.friendly_pins_moves_bbs[square]); }
 
         *attacked_squares |= raw_attacks;
 
@@ -344,10 +422,14 @@ impl MoveGenerator {
         };
 
         let raw_forward_one = offset_fn(bb_position) & !occupied_squares;
-        let mut forward_one = raw_forward_one & attack_data.friendly_pins_moves_bbs[square] & attack_data.defenders_bb;
+        let mut forward_one = raw_forward_one
+            & attack_data.friendly_pins_moves_bbs[square]
+            & attack_data.defenders_bb;
 
         if is_pawn_in_initial_position(bb_position, color.is_white()) {
-            let mut forward_two = (offset_fn(raw_forward_one) & !occupied_squares) & attack_data.friendly_pins_moves_bbs[square] & attack_data.defenders_bb;
+            let mut forward_two = (offset_fn(raw_forward_one) & !occupied_squares)
+                & attack_data.friendly_pins_moves_bbs[square]
+                & attack_data.defenders_bb;
 
             // *attacked_squares |= forward_two;
 
@@ -372,7 +454,9 @@ impl MoveGenerator {
         } else if board.get_en_passant() != 0 {
             let mut attacks = (MoveGenerator::look_up_pawn_attacks(color, square)
                 & !friendly_pieces_bb)
-                & board.get_en_passant() & attack_data.friendly_pins_moves_bbs[square] & (attack_data.defenders_bb | attack_data.attack_bb);
+                & board.get_en_passant()
+                & attack_data.friendly_pins_moves_bbs[square]
+                & (attack_data.defenders_bb | attack_data.attack_bb);
 
             // *attacked_squares |= attacks;
 
@@ -445,7 +529,8 @@ mod tests {
 
     use super::{MoveGenerator, DOUBLE_PAWN_PUSH, EN_PASSANT};
 
-    static MOVE_GENERATOR: Lazy<Mutex<MoveGenerator>> = Lazy::new(|| Mutex::new(MoveGenerator::new()));
+    static MOVE_GENERATOR: Lazy<Mutex<MoveGenerator>> =
+        Lazy::new(|| Mutex::new(MoveGenerator::new()));
 
     fn assert_available_moves(
         board: &mut Board, expected_moves: Vec<Move>, not_expected_moves: Vec<Move>,

--- a/ai-engine/src/game_bit_board/move_generator/move_generator.rs
+++ b/ai-engine/src/game_bit_board/move_generator/move_generator.rs
@@ -587,15 +587,15 @@ mod tests {
     fn test_castle() {
         let (
             mut board,
-            white_king_side_castle,
-            white_queen_side_castle,
-            black_king_side_castle,
-            black_queen_side_castle,
+            mut white_king_side_castle,
+            mut white_queen_side_castle,
+            mut black_king_side_castle,
+            mut black_queen_side_castle,
         ) = set_up_castle_position();
 
         // White: Make sure castle rights are lost after castle is performed
 
-        board.move_piece(&white_king_side_castle);
+        board.move_piece(&mut white_king_side_castle);
 
         assert_eq!(false, board.has_king_side_castle_right(Color::White));
         assert_eq!(false, board.has_queen_side_castle_right(Color::White));
@@ -608,7 +608,7 @@ mod tests {
         assert_eq!(true, board.has_king_side_castle_right(Color::White));
         assert_eq!(true, board.has_queen_side_castle_right(Color::White));
 
-        board.move_piece(&white_queen_side_castle);
+        board.move_piece(&mut white_queen_side_castle);
 
         assert_eq!(false, board.has_king_side_castle_right(Color::White));
         assert_eq!(false, board.has_queen_side_castle_right(Color::White));
@@ -621,7 +621,7 @@ mod tests {
         assert_eq!(true, board.has_king_side_castle_right(Color::White));
         assert_eq!(true, board.has_queen_side_castle_right(Color::White));
 
-        board.move_piece(&Move::dummy_from_to(Squares::E1, Squares::E2));
+        board.move_piece(&mut Move::dummy_from_to(Squares::E1, Squares::E2));
 
         assert_eq!(false, board.has_king_side_castle_right(Color::White));
         assert_eq!(false, board.has_queen_side_castle_right(Color::White));
@@ -631,21 +631,21 @@ mod tests {
         assert_eq!(true, board.has_king_side_castle_right(Color::White));
         assert_eq!(true, board.has_queen_side_castle_right(Color::White));
 
-        board.move_piece(&Move::dummy_from_to(Squares::A1, Squares::B1));
+        board.move_piece(&mut Move::dummy_from_to(Squares::A1, Squares::B1));
 
         assert_eq!(true, board.has_king_side_castle_right(Color::White));
         assert_eq!(false, board.has_queen_side_castle_right(Color::White));
 
         board.unmake_last_move();
 
-        board.move_piece(&Move::dummy_from_to(Squares::H1, Squares::G1));
+        board.move_piece(&mut Move::dummy_from_to(Squares::H1, Squares::G1));
 
         assert_eq!(false, board.has_king_side_castle_right(Color::White));
         assert_eq!(true, board.has_queen_side_castle_right(Color::White));
 
         // Black: Make sure castle rights are lost after castle is performed
 
-        board.move_piece(&black_king_side_castle);
+        board.move_piece(&mut black_king_side_castle);
 
         assert_eq!(false, board.has_king_side_castle_right(Color::Black));
         assert_eq!(false, board.has_queen_side_castle_right(Color::Black));
@@ -658,7 +658,7 @@ mod tests {
         assert_eq!(true, board.has_king_side_castle_right(Color::Black));
         assert_eq!(true, board.has_queen_side_castle_right(Color::Black));
 
-        board.move_piece(&black_queen_side_castle);
+        board.move_piece(&mut black_queen_side_castle);
 
         assert_eq!(PieceType::King, board.get_piece_type(Squares::C8));
         assert_eq!(PieceType::Rook, board.get_piece_type(Squares::D8));
@@ -671,7 +671,7 @@ mod tests {
         assert_eq!(true, board.has_king_side_castle_right(Color::Black));
         assert_eq!(true, board.has_queen_side_castle_right(Color::Black));
 
-        board.move_piece(&Move::dummy_from_to(Squares::E8, Squares::E7));
+        board.move_piece(&mut Move::dummy_from_to(Squares::E8, Squares::E7));
 
         assert_eq!(false, board.has_king_side_castle_right(Color::Black));
         assert_eq!(false, board.has_queen_side_castle_right(Color::Black));
@@ -681,14 +681,14 @@ mod tests {
         assert_eq!(true, board.has_king_side_castle_right(Color::Black));
         assert_eq!(true, board.has_queen_side_castle_right(Color::Black));
 
-        board.move_piece(&Move::dummy_from_to(Squares::A8, Squares::B8));
+        board.move_piece(&mut Move::dummy_from_to(Squares::A8, Squares::B8));
 
         assert_eq!(true, board.has_king_side_castle_right(Color::Black));
         assert_eq!(false, board.has_queen_side_castle_right(Color::Black));
 
         board.unmake_last_move();
 
-        board.move_piece(&Move::dummy_from_to(Squares::H8, Squares::G8));
+        board.move_piece(&mut Move::dummy_from_to(Squares::H8, Squares::G8));
 
         assert_eq!(false, board.has_king_side_castle_right(Color::Black));
         assert_eq!(true, board.has_queen_side_castle_right(Color::Black));
@@ -721,20 +721,20 @@ mod tests {
               a b c d e f g h
         */
 
-        board.move_piece(&Move::dummy_from_to(Squares::D2, Squares::D4));
-        board.move_piece(&Move::dummy_from_to(Squares::D7, Squares::D5));
-        board.move_piece(&Move::dummy_from_to(Squares::E2, Squares::E4));
-        board.move_piece(&Move::dummy_from_to(Squares::E7, Squares::E5));
-        board.move_piece(&Move::dummy_from_to(Squares::C1, Squares::H6));
-        board.move_piece(&Move::dummy_from_to(Squares::C8, Squares::H3));
-        board.move_piece(&Move::dummy_from_to(Squares::F1, Squares::A6));
-        board.move_piece(&Move::dummy_from_to(Squares::F8, Squares::A3));
-        board.move_piece(&Move::dummy_from_to(Squares::D1, Squares::D2));
-        board.move_piece(&Move::dummy_from_to(Squares::D8, Squares::D7));
-        board.move_piece(&Move::dummy_from_to(Squares::B1, Squares::C3));
-        board.move_piece(&Move::dummy_from_to(Squares::B8, Squares::C6));
-        board.move_piece(&Move::dummy_from_to(Squares::G1, Squares::F3));
-        board.move_piece(&Move::dummy_from_to(Squares::G8, Squares::F6));
+        board.move_piece(&mut Move::dummy_from_to(Squares::D2, Squares::D4));
+        board.move_piece(&mut Move::dummy_from_to(Squares::D7, Squares::D5));
+        board.move_piece(&mut Move::dummy_from_to(Squares::E2, Squares::E4));
+        board.move_piece(&mut Move::dummy_from_to(Squares::E7, Squares::E5));
+        board.move_piece(&mut Move::dummy_from_to(Squares::C1, Squares::H6));
+        board.move_piece(&mut Move::dummy_from_to(Squares::C8, Squares::H3));
+        board.move_piece(&mut Move::dummy_from_to(Squares::F1, Squares::A6));
+        board.move_piece(&mut Move::dummy_from_to(Squares::F8, Squares::A3));
+        board.move_piece(&mut Move::dummy_from_to(Squares::D1, Squares::D2));
+        board.move_piece(&mut Move::dummy_from_to(Squares::D8, Squares::D7));
+        board.move_piece(&mut Move::dummy_from_to(Squares::B1, Squares::C3));
+        board.move_piece(&mut Move::dummy_from_to(Squares::B8, Squares::C6));
+        board.move_piece(&mut Move::dummy_from_to(Squares::G1, Squares::F3));
+        board.move_piece(&mut Move::dummy_from_to(Squares::G8, Squares::F6));
 
         board.display();
 
@@ -780,10 +780,10 @@ mod tests {
     fn test_pins() {
         let mut board = Board::new();
 
-        board.move_piece(&Move::dummy_from_to(Squares::A2, Squares::A3));
-        board.move_piece(&Move::dummy_from_to(Squares::E7, Squares::E6));
-        board.move_piece(&Move::dummy_from_to(Squares::A3, Squares::A4));
-        board.move_piece(&Move::dummy_from_to(Squares::D8, Squares::H4));
+        board.move_piece(&mut Move::dummy_from_to(Squares::A2, Squares::A3));
+        board.move_piece(&mut Move::dummy_from_to(Squares::E7, Squares::E6));
+        board.move_piece(&mut Move::dummy_from_to(Squares::A3, Squares::A4));
+        board.move_piece(&mut Move::dummy_from_to(Squares::D8, Squares::H4));
 
         board.display();
 
@@ -826,7 +826,7 @@ mod tests {
         assert_available_moves(&mut board, white_king_castle_moves.clone(), Vec::new());
 
         // Make a move to give turn to Black
-        board.move_piece(&Move::dummy_from_to(Squares::B2, Squares::B4));
+        board.move_piece(&mut Move::dummy_from_to(Squares::B2, Squares::B4));
 
         // Assert black have both castle moves available
 
@@ -837,12 +837,12 @@ mod tests {
 
         assert_available_moves(&mut board, black_king_castle_moves.clone(), Vec::new());
 
-        board.move_piece(&Move::dummy_from_to(Squares::B7, Squares::B5));
-        board.move_piece(&Move::dummy_from_to(Squares::G2, Squares::G4));
+        board.move_piece(&mut Move::dummy_from_to(Squares::B7, Squares::B5));
+        board.move_piece(&mut Move::dummy_from_to(Squares::G2, Squares::G4));
 
         assert_available_moves(&mut board, Vec::new(), white_king_castle_moves);
 
-        board.move_piece(&Move::dummy_from_to(Squares::G7, Squares::G5));
+        board.move_piece(&mut Move::dummy_from_to(Squares::G7, Squares::G5));
 
         board.display();
 
@@ -1105,7 +1105,7 @@ mod tests {
 
         let mut expected_moves = Vec::new();
 
-        let white_knight_to_c3 =
+        let mut white_knight_to_c3 =
             Move::from_to(Squares::B1, Squares::C3, Color::White, PieceType::Knight);
 
         expected_moves.push(white_knight_to_c3.clone());
@@ -1118,8 +1118,8 @@ mod tests {
 
         assert_available_moves(&mut board, expected_moves, Vec::new());
 
-        board.move_piece(&white_knight_to_c3);
-        board.move_piece(&Move::dummy_from_to(Squares::D7, Squares::D5));
+        board.move_piece(&mut white_knight_to_c3);
+        board.move_piece(&mut Move::dummy_from_to(Squares::D7, Squares::D5));
 
         let white_knight_to_d5 = Move::with_flags(
             CAPTURE,
@@ -1157,7 +1157,7 @@ mod tests {
 
         assert_available_moves(&mut board, expected_moves, Vec::new());
 
-        board.move_piece(&white_pawn_to_d4);
+        board.move_piece(&mut white_pawn_to_d4);
 
         expected_moves = Vec::new();
 
@@ -1174,7 +1174,7 @@ mod tests {
 
         expected_moves.push(black_pawn_to_e5.clone());
 
-        board.move_piece(&black_pawn_to_e5);
+        board.move_piece(&mut black_pawn_to_e5);
 
         expected_moves = Vec::new();
 
@@ -1193,21 +1193,21 @@ mod tests {
     fn test_get_en_passant() {
         let mut board = Board::new();
 
-        board.move_piece(&Move::dummy_with_flags(
+        board.move_piece(&mut Move::dummy_with_flags(
             DOUBLE_PAWN_PUSH,
             Squares::D2,
             Squares::D4,
         ));
-        board.move_piece(&Move::dummy_from_to(Squares::A7, Squares::A6));
-        board.move_piece(&Move::dummy_from_to(Squares::D4, Squares::D5));
-        board.move_piece(&Move::dummy_from_to(Squares::A6, Squares::A5));
-        board.move_piece(&Move::dummy_with_flags(
+        board.move_piece(&mut Move::dummy_from_to(Squares::A7, Squares::A6));
+        board.move_piece(&mut Move::dummy_from_to(Squares::D4, Squares::D5));
+        board.move_piece(&mut Move::dummy_from_to(Squares::A6, Squares::A5));
+        board.move_piece(&mut Move::dummy_with_flags(
             DOUBLE_PAWN_PUSH,
             Squares::F2,
             Squares::F4,
         ));
-        board.move_piece(&Move::dummy_from_to(Squares::A5, Squares::A4));
-        board.move_piece(&Move::dummy_from_to(Squares::F4, Squares::F5));
+        board.move_piece(&mut Move::dummy_from_to(Squares::A5, Squares::A4));
+        board.move_piece(&mut Move::dummy_from_to(Squares::F4, Squares::F5));
 
         /*
             8 ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜
@@ -1239,7 +1239,7 @@ mod tests {
 
         assert_available_moves(&mut board, expected_moves, Vec::new());
 
-        board.move_piece(&black_double_push);
+        board.move_piece(&mut black_double_push);
 
         expected_moves = Vec::new();
 

--- a/ai-engine/src/game_bit_board/move_generator/raw_move_generator.rs
+++ b/ai-engine/src/game_bit_board/move_generator/raw_move_generator.rs
@@ -12,10 +12,11 @@ use super::contants::{BISHOP_RELEVANT_SQUARES, ROOK_RELEVANT_SQUARES};
 
 pub struct RawMoveGenerator {}
 
+/// Most methods in this struct were used once to generate pre-computed moves.
 impl RawMoveGenerator {
     pub fn new() -> Self { RawMoveGenerator {} }
 
-    /// Borrowed from Sebastian Lague https://youtu.be/_vqlIPDR2TU?feature=shared&t=1902
+    // Borrowed from Sebastian Lague https://youtu.be/_vqlIPDR2TU?feature=shared&t=1902
     fn get_blockers_bitboards(bb_moves: u64) -> Vec<u64> {
         let mut square_indices = Vec::new();
 
@@ -262,8 +263,6 @@ impl RawMoveGenerator {
         RawMoveGenerator::pre_compute_slider_moves(&RawMoveGenerator::generate_rook_moves)
     }
 
-    /// This function was used once to generate king pseudo-legal moves
-    /// It will be kept here for the sake of history.
     fn generate_king_moves(friendly_positions: u64, initial_position: u64) -> u64 {
         (north_one(initial_position)
             | no_ea_one(initial_position)
@@ -276,8 +275,6 @@ impl RawMoveGenerator {
             & !friendly_positions
     }
 
-    /// This function was used once to generate king pseudo-legal moves
-    /// It will be kept here for the sake of history.
     fn pre_compute_king_moves(moves_vec: &mut [u64; 64]) {
         let start = 0;
         let end = 63;
@@ -289,8 +286,6 @@ impl RawMoveGenerator {
         }
     }
 
-    /// This function was used once to generate knight moves
-    /// It will be kept here for the sake of history.
     fn pre_compute_knight_moves(moves_vec: &mut [u64; 64]) {
         let start = 0;
         let end = 63;
@@ -312,8 +307,6 @@ impl RawMoveGenerator {
         }
     }
 
-    /// This function was used once to generate knight moves
-    /// It will be kept here for the sake of history.
     fn get_knight_moves(
         initial_position: u64, moves: &mut u64, north_or_south_one: &dyn Fn(u64) -> u64,
     ) {
@@ -334,8 +327,6 @@ impl RawMoveGenerator {
         *moves |= east_one(north_16);
     }
 
-    /// This function was used once to generate the pawn attacks
-    /// It will be kept here for the sake of history.
     fn pre_compute_pawn_attacks(
         moves_vec: &mut [u64; 64], ea_one_fn: &dyn Fn(u64) -> u64, we_one_fn: &dyn Fn(u64) -> u64,
     ) {
@@ -346,8 +337,6 @@ impl RawMoveGenerator {
         }
     }
 
-    /// This function was used once to generate the pawn moves
-    /// It will be kept here for the sake of history.
     fn pre_compute_pawn_moves(moves_vec: &mut [u64; 64], white: bool) {
         let offset_fn = if white { north_one } else { south_one };
 

--- a/ai-engine/src/game_bit_board/move_generator/raw_move_generator.rs
+++ b/ai-engine/src/game_bit_board/move_generator/raw_move_generator.rs
@@ -5,13 +5,10 @@ use crate::game_bit_board::utils::{
         east_one, no_ea_one, no_we_one, north_one, so_ea_one, so_we_one, south_one,
         to_bitboard_position, west_one,
     },
-    utils::{get_piece_symbol, is_pawn_in_initial_position},
+    utils::is_pawn_in_initial_position,
 };
 
-use super::{
-    super::enums::{Color, PieceType},
-    contants::{BISHOP_RELEVANT_SQUARES, ROOK_RELEVANT_SQUARES},
-};
+use super::contants::{BISHOP_RELEVANT_SQUARES, ROOK_RELEVANT_SQUARES};
 
 pub struct RawMoveGenerator {}
 
@@ -366,40 +363,13 @@ impl RawMoveGenerator {
     }
 }
 
-fn print_board(color: Color, piece_square: u64, piece_type: PieceType, bb_position: u64) {
-    println!("  a b c d e f g h");
-    for rank in (0..8).rev() {
-        print!("{} ", rank + 1);
-
-        for file in 0..8 {
-            let square = 1 << (rank * 8 + file);
-
-            if square == 1 << piece_square {
-                let symbol = get_piece_symbol(color, piece_type);
-
-                print!("{symbol} ");
-            } else if bb_position & square != 0 {
-                print!("1 ");
-            } else {
-                print!(". ");
-            }
-        }
-
-        println!("{}", rank + 1);
-    }
-
-    println!("  a b c d e f g h");
-    println!("{:#018X}", bb_position)
-}
-
 #[cfg(test)]
 mod tests {
 
     use crate::game_bit_board::{
         enums::{Color, PieceType},
         move_generator::{
-            contants::{BISHOP_RELEVANT_SQUARES, ROOK_RELEVANT_SQUARES},
-            raw_move_generator::print_board,
+            contants::{BISHOP_RELEVANT_SQUARES, ROOK_RELEVANT_SQUARES}, utils::print_board,
         },
         positions::BBPositions,
         utils::utils::memory_usage_in_kb,

--- a/ai-engine/src/game_bit_board/move_generator/raw_move_generator.rs
+++ b/ai-engine/src/game_bit_board/move_generator/raw_move_generator.rs
@@ -369,7 +369,8 @@ mod tests {
     use crate::game_bit_board::{
         enums::{Color, PieceType},
         move_generator::{
-            contants::{BISHOP_RELEVANT_SQUARES, ROOK_RELEVANT_SQUARES}, utils::print_board,
+            contants::{BISHOP_RELEVANT_SQUARES, ROOK_RELEVANT_SQUARES},
+            utils::print_board,
         },
         positions::BBPositions,
         utils::utils::memory_usage_in_kb,

--- a/ai-engine/src/game_bit_board/move_generator/utils.rs
+++ b/ai-engine/src/game_bit_board/move_generator/utils.rs
@@ -3,7 +3,8 @@ use crate::game_bit_board::{
     enums::{Color, PieceType},
     utils::{
         bitwise_utils::{
-            east_one, no_ea_one, no_we_one, north_one, pop_lsb, so_ea_one, so_we_one, south_one, to_bitboard_position, west_one
+            east_one, no_ea_one, no_we_one, north_one, pop_lsb, so_ea_one, so_we_one, south_one,
+            to_bitboard_position, west_one,
         },
         utils::get_piece_symbol,
     },

--- a/ai-engine/src/game_bit_board/move_generator/utils.rs
+++ b/ai-engine/src/game_bit_board/move_generator/utils.rs
@@ -1,4 +1,4 @@
-use crate::game_bit_board::{enums::{Color, PieceType}, utils::{bitwise_utils::{east_one, no_ea_one, no_we_one, north_one, so_ea_one, so_we_one, south_one, west_one}, utils::get_piece_symbol}};
+use crate::game_bit_board::{_move::{_move::Move, move_contants::CAPTURE}, enums::{Color, PieceType}, utils::{bitwise_utils::{east_one, no_ea_one, no_we_one, north_one, pop_lsb, so_ea_one, so_we_one, south_one, to_bitboard_position, west_one}, utils::get_piece_symbol}};
 
 pub fn print_board(color: Color, piece_square: u64, piece_type: PieceType, bb_position: u64) {
     println!("  a b c d e f g h");
@@ -27,37 +27,109 @@ pub fn print_board(color: Color, piece_square: u64, piece_type: PieceType, bb_po
     println!("{:#018X}", bb_position)
 }
 
-pub fn get_king_attacker_positions(bb_position: u64) -> u64 {
-    let mut positions = 0_u64;
+pub fn create_moves(mut attacks: u64, opponent_pieces_bb: u64, moves: &mut Vec<Move>, square: usize, color: Color, piece_type: PieceType) {
+    while attacks != 0 {
+        let target_square = pop_lsb(&mut attacks);
 
-    [north_one, south_one, west_one, east_one, 
-    no_ea_one, no_we_one, so_ea_one, so_we_one].iter().for_each(|f| {
-        let mut pos = f(bb_position);
-
-        while pos != 0 {
-            positions |= pos;
-
-            pos = f(pos);
+        let mut flags: u16 = 0;
+        if to_bitboard_position(target_square as u64) & opponent_pieces_bb != 0 {
+            flags = CAPTURE;
         }
-    });
+
+        moves.push(Move::with_flags(
+            flags,
+            square,
+            target_square as usize,
+            color,
+            piece_type,
+        ));
+    }
+}
+
+pub fn get_king_relevant_squares_related_to_enemy_pawns(inital_pos: u64) -> u64 {
+    let mut positions = 0;
+
+    let _west_one = west_one(inital_pos);
+
+    positions |= _west_one;
+
+    let west_two = west_one(_west_one);
+
+    positions |= west_two;
+
+    // East
+
+    let _east_one = east_one(inital_pos);
+
+    positions |= _east_one;
+
+    let east_two = east_one(_east_one);
+
+    positions |= east_two;
+
+    // North one
+
+    let _north_one = north_one(inital_pos);
+
+    positions |= _north_one;
+
+    // North west
+
+    let _no_we_one = no_we_one(inital_pos);
+
+    positions |= _no_we_one;
+
+    let _no_we_we = west_one(_no_we_one);
+
+    positions |= _no_we_we;
+
+    // North east
+
+    let _no_ea_one = no_ea_one(inital_pos);
+
+    positions |= _no_ea_one;
+
+    let _no_ea_ea = east_one(_no_ea_one);
+
+    positions |= _no_ea_ea;
+
+    // North two
+
+    let _north_two = north_one(_north_one);
+
+    positions |= _north_two;
+
+    // North north west
+
+    let _no_no_we = west_one(_north_two);
+
+    positions |= _no_no_we;
+
+    let _no_no_we_we = west_one(_no_no_we);
+
+    positions |= _no_no_we_we;
+
+    // North north east
+
+    let _no_no_ea = east_one(_north_two);
+
+    positions |= _no_no_ea;
+
+    let _no_no_ea_ea = east_one(_no_no_ea);
+
+    positions |= _no_no_ea_ea;
 
     positions
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::game_bit_board::{enums::{Color, PieceType}, positions::Squares, utils::bitwise_utils::to_bitboard_position};
+    use crate::game_bit_board::{enums::{Color, PieceType}, positions::{BBPositions, Squares}};
 
-    use super::{get_king_attacker_positions, print_board};
-
+    use super::{get_king_relevant_squares_related_to_enemy_pawns, print_board};
 
     #[test]
-    pub fn test_get_king_possible_attackers_positions() {
-        let positions = get_king_attacker_positions(to_bitboard_position(Squares::D5 as u64));
-
-        print_board(Color::White, Squares::D5 as u64, PieceType::King, positions);
-
-        assert_eq!(0x492A1CF71C2A4988, positions)
+    fn test_get_king_relevant_squares_related_to_enemy_pawns() {
+        print_board(Color::White, Squares::E1 as u64, PieceType::King, get_king_relevant_squares_related_to_enemy_pawns(BBPositions::E1));
     }
-
 }

--- a/ai-engine/src/game_bit_board/move_generator/utils.rs
+++ b/ai-engine/src/game_bit_board/move_generator/utils.rs
@@ -1,4 +1,14 @@
-use crate::game_bit_board::{_move::{_move::Move, move_contants::CAPTURE}, enums::{Color, PieceType}, utils::{bitwise_utils::{east_one, no_ea_one, no_we_one, north_one, pop_lsb, so_ea_one, so_we_one, south_one, to_bitboard_position, west_one}, utils::get_piece_symbol}};
+use crate::game_bit_board::{
+    _move::{_move::Move, move_contants::CAPTURE},
+    enums::{Color, PieceType},
+    utils::{
+        bitwise_utils::{
+            east_one, no_ea_one, no_we_one, north_one, pop_lsb, so_ea_one, so_we_one, south_one,
+            to_bitboard_position, west_one,
+        },
+        utils::get_piece_symbol,
+    },
+};
 
 pub fn print_board(color: Color, piece_square: u64, piece_type: PieceType, bb_position: u64) {
     println!("  a b c d e f g h");
@@ -27,7 +37,10 @@ pub fn print_board(color: Color, piece_square: u64, piece_type: PieceType, bb_po
     println!("{:#018X}", bb_position)
 }
 
-pub fn create_moves(mut attacks: u64, opponent_pieces_bb: u64, moves: &mut Vec<Move>, square: usize, color: Color, piece_type: PieceType) {
+pub fn create_moves(
+    mut attacks: u64, opponent_pieces_bb: u64, moves: &mut Vec<Move>, square: usize, color: Color,
+    piece_type: PieceType,
+) {
     while attacks != 0 {
         let target_square = pop_lsb(&mut attacks);
 
@@ -124,12 +137,20 @@ pub fn get_king_relevant_squares_related_to_enemy_pawns(inital_pos: u64) -> u64 
 
 #[cfg(test)]
 mod tests {
-    use crate::game_bit_board::{enums::{Color, PieceType}, positions::{BBPositions, Squares}};
+    use crate::game_bit_board::{
+        enums::{Color, PieceType},
+        positions::{BBPositions, Squares},
+    };
 
     use super::{get_king_relevant_squares_related_to_enemy_pawns, print_board};
 
     #[test]
     fn test_get_king_relevant_squares_related_to_enemy_pawns() {
-        print_board(Color::White, Squares::E1 as u64, PieceType::King, get_king_relevant_squares_related_to_enemy_pawns(BBPositions::E1));
+        print_board(
+            Color::White,
+            Squares::E1 as u64,
+            PieceType::King,
+            get_king_relevant_squares_related_to_enemy_pawns(BBPositions::E1),
+        );
     }
 }

--- a/ai-engine/src/game_bit_board/move_generator/utils.rs
+++ b/ai-engine/src/game_bit_board/move_generator/utils.rs
@@ -1,0 +1,63 @@
+use crate::game_bit_board::{enums::{Color, PieceType}, utils::{bitwise_utils::{east_one, no_ea_one, no_we_one, north_one, so_ea_one, so_we_one, south_one, west_one}, utils::get_piece_symbol}};
+
+pub fn print_board(color: Color, piece_square: u64, piece_type: PieceType, bb_position: u64) {
+    println!("  a b c d e f g h");
+    for rank in (0..8).rev() {
+        print!("{} ", rank + 1);
+
+        for file in 0..8 {
+            let square = rank * 8 + file;
+            let position = 1 << square;
+
+            if square == piece_square {
+                let symbol = get_piece_symbol(color, piece_type);
+
+                print!("{symbol} ");
+            } else if bb_position & position != 0 {
+                print!("1 ");
+            } else {
+                print!(". ");
+            }
+        }
+
+        println!("{}", rank + 1);
+    }
+
+    println!("  a b c d e f g h");
+    println!("{:#018X}", bb_position)
+}
+
+pub fn get_king_attacker_positions(bb_position: u64) -> u64 {
+    let mut positions = 0_u64;
+
+    [north_one, south_one, west_one, east_one, 
+    no_ea_one, no_we_one, so_ea_one, so_we_one].iter().for_each(|f| {
+        let mut pos = f(bb_position);
+
+        while pos != 0 {
+            positions |= pos;
+
+            pos = f(pos);
+        }
+    });
+
+    positions
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::game_bit_board::{enums::{Color, PieceType}, positions::Squares, utils::bitwise_utils::to_bitboard_position};
+
+    use super::{get_king_attacker_positions, print_board};
+
+
+    #[test]
+    pub fn test_get_king_possible_attackers_positions() {
+        let positions = get_king_attacker_positions(to_bitboard_position(Squares::D5 as u64));
+
+        print_board(Color::White, Squares::D5 as u64, PieceType::King, positions);
+
+        assert_eq!(0x492A1CF71C2A4988, positions)
+    }
+
+}

--- a/ai-engine/src/game_bit_board/move_generator/utils.rs
+++ b/ai-engine/src/game_bit_board/move_generator/utils.rs
@@ -3,8 +3,7 @@ use crate::game_bit_board::{
     enums::{Color, PieceType},
     utils::{
         bitwise_utils::{
-            east_one, no_ea_one, no_we_one, north_one, pop_lsb,
-            to_bitboard_position, west_one,
+            east_one, no_ea_one, no_we_one, north_one, pop_lsb, so_ea_one, so_we_one, south_one, to_bitboard_position, west_one
         },
         utils::get_piece_symbol,
     },
@@ -131,6 +130,58 @@ pub fn get_king_relevant_squares_related_to_enemy_pawns(inital_pos: u64) -> u64 
     let _no_no_ea_ea = east_one(_no_no_ea);
 
     positions |= _no_no_ea_ea;
+
+    // South one
+
+    let _south_one = south_one(inital_pos);
+
+    positions |= _south_one;
+
+    // South west
+
+    let _so_we_one = so_we_one(inital_pos);
+
+    positions |= _so_we_one;
+
+    let _so_we_we = west_one(_so_we_one);
+
+    positions |= _so_we_we;
+
+    // South east
+
+    let _so_ea_one = so_ea_one(inital_pos);
+
+    positions |= _so_ea_one;
+
+    let _so_ea_ea = east_one(_so_ea_one);
+
+    positions |= _so_ea_ea;
+
+    // South two
+
+    let _south_two = south_one(_south_one);
+
+    positions |= _south_two;
+
+    // South south west
+
+    let _so_so_we = west_one(_south_two);
+
+    positions |= _so_so_we;
+
+    let _so_so_we_we = west_one(_so_so_we);
+
+    positions |= _so_so_we_we;
+
+    // South south east
+
+    let _so_so_ea = east_one(_south_two);
+
+    positions |= _so_so_ea;
+
+    let _so_so_ea_ea = east_one(_so_so_ea);
+
+    positions |= _so_so_ea_ea;
 
     positions
 }

--- a/ai-engine/src/game_bit_board/move_generator/utils.rs
+++ b/ai-engine/src/game_bit_board/move_generator/utils.rs
@@ -3,7 +3,7 @@ use crate::game_bit_board::{
     enums::{Color, PieceType},
     utils::{
         bitwise_utils::{
-            east_one, no_ea_one, no_we_one, north_one, pop_lsb, so_ea_one, so_we_one, south_one,
+            east_one, no_ea_one, no_we_one, north_one, pop_lsb,
             to_bitboard_position, west_one,
         },
         utils::get_piece_symbol,

--- a/ai-engine/src/game_bit_board/move_generator/utils.rs
+++ b/ai-engine/src/game_bit_board/move_generator/utils.rs
@@ -1,6 +1,8 @@
 use crate::game_bit_board::{
     _move::{_move::Move, move_contants::CAPTURE},
+    board::Board,
     enums::{Color, PieceType},
+    positions::{same_rank, BBPositions, Squares},
     utils::{
         bitwise_utils::{
             east_one, no_ea_one, no_we_one, north_one, pop_lsb, so_ea_one, so_we_one, south_one,
@@ -8,6 +10,11 @@ use crate::game_bit_board::{
         },
         utils::get_piece_symbol,
     },
+};
+
+use super::{
+    attack_data::AttackData,
+    contants::{BLACK_PAWN_ATTACKS, WHITE_PAWN_ATTACKS},
 };
 
 pub fn print_board(color: Color, piece_square: u64, piece_type: PieceType, bb_position: u64) {
@@ -59,6 +66,103 @@ pub fn create_moves(
     }
 }
 
+pub fn is_en_passant_discovered_check(
+    color: Color, attack_data: &AttackData, square: usize, board: &Board,
+) -> bool {
+    if color != attack_data.side_to_move || !same_rank(square, attack_data.king_square) {
+        return false;
+    }
+
+    let row = BBPositions::get_row_bb(attack_data.king_bb_position);
+
+    let opponent = attack_data.side_to_move.opponent();
+
+    let opponent_queens = board.get_piece_positions(opponent, PieceType::Queen) & row;
+
+    let opponent_rooks = board.get_piece_positions(opponent, PieceType::Rook) & row;
+
+    if opponent_rooks == 0 && opponent_queens == 0 {
+        return false;
+    }
+
+    let friendly_pieces = board.get_player_pieces_positions(attack_data.side_to_move);
+    let opponent_pieces = board.get_player_pieces_positions(opponent);
+    let mut row_occupied_squares = (friendly_pieces | opponent_pieces) & row;
+
+    // Remove friendly and enemy pawns involved in en passant
+    row_occupied_squares &= !board.get_en_passant_piece_square_bb();
+    row_occupied_squares &= !to_bitboard_position(square as u64);
+
+    let mut squares_between_rook_and_king = 0;
+    if opponent_rooks != 0 {
+        let closest_rook_square = get_closest_square(attack_data.king_square, opponent_rooks);
+
+        squares_between_rook_and_king =
+            squares_between(attack_data.king_square, closest_rook_square);
+    }
+
+    let mut squares_between_queen_and_king = 0;
+    if opponent_queens != 0 {
+        let closest_queen_square = get_closest_square(attack_data.king_square, opponent_queens);
+
+        if closest_queen_square != 0 {
+            squares_between_queen_and_king =
+                squares_between(attack_data.king_square, closest_queen_square);
+        }
+    }
+
+    let squares_between_king = squares_between_rook_and_king | squares_between_queen_and_king;
+
+    // After removing all those pieces, if the row is empty, it means there aren't
+    // other pieces (either friendly or not) that would protect the king
+    if squares_between_king & row_occupied_squares == 0 {
+        return true;
+    }
+
+    false
+}
+
+pub fn squares_between(sq1: usize, sq2: usize) -> u64 {
+    if sq1 < sq2 {
+        ((sq1 + 1)..sq2).fold(0, |acc, sq| acc | (1 << sq))
+    } else {
+        ((sq2 + 1)..sq1).fold(0, |acc, sq| acc | (1 << sq))
+    }
+}
+
+pub fn get_closest_square(base_square: usize, pieces: u64) -> usize {
+    let mut closest_square = usize::MAX;
+
+    let mut pieces = pieces.clone();
+
+    while pieces != 0 {
+        let square = pop_lsb(&mut pieces) as usize;
+
+        if base_square.abs_diff(square) < closest_square {
+            closest_square = square;
+        }
+    }
+
+    closest_square
+}
+
+pub fn look_up_pawn_attacks(color: Color, square: usize) -> u64 {
+    if color.is_white() {
+        WHITE_PAWN_ATTACKS[square]
+    } else {
+        BLACK_PAWN_ATTACKS[square]
+    }
+}
+
+pub fn is_promotion_square(color: Color, square: usize) -> bool {
+    if square >= Squares::A8 && square <= Squares::H8 && color.is_white() {
+        return true;
+    }
+
+    square >= Squares::A1 && square <= Squares::H1 && color.is_black()
+}
+
+// TODO: pre-calculate this for every square, as I did for sliding pieces
 pub fn get_king_relevant_squares_related_to_enemy_pawns(inital_pos: u64) -> u64 {
     let mut positions = 0;
 

--- a/ai-engine/src/game_bit_board/positions.rs
+++ b/ai-engine/src/game_bit_board/positions.rs
@@ -249,3 +249,69 @@ impl BBPositions {
     }
   }
 }
+
+pub fn same_rank(sq1: usize, sq2: usize) -> bool {
+    sq1 / 8 == sq2 / 8 // Divide by 8 to get the rank (row)
+}
+
+pub fn same_file(sq1: usize, sq2: usize) -> bool {
+    sq1 % 8 == sq2 % 8 // Modulo 8 to get the file (column)
+}
+
+pub fn same_diagonal(sq1: usize, sq2: usize) -> bool {
+    (sq1 / 8) as isize - (sq1 % 8) as isize == (sq2 / 8) as isize - (sq2 % 8) as isize
+}
+
+pub fn same_anti_diagonal(sq1: usize, sq2: usize) -> bool {
+    (sq1 / 8) as isize + (sq1 % 8) as isize == (sq2 / 8) as isize + (sq2 % 8) as isize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_same_rank() {
+        // A1 and H1 are on the same rank
+        assert!(same_rank(Squares::A1, Squares::H1));
+        // A1 and A2 are not on the same rank
+        assert!(!same_rank(Squares::A1, Squares::A2));
+        // D4 and G4 are on the same rank
+        assert!(same_rank(Squares::D4, Squares::G4));
+    }
+
+    #[test]
+    fn test_same_file() {
+        // A1 and A8 are on the same file
+        assert!(same_file(Squares::A1, Squares::A8));
+        // A1 and B1 are not on the same file
+        assert!(!same_file(Squares::A1, Squares::H1));
+        // D4 and D7 are on the same file
+        assert!(same_file(Squares::D4, Squares::D4 + 24)); // D4 (27) and D7 (27 + 24)
+    }
+
+    #[test]
+    fn test_same_diagonal() {
+        // A1 and H8 are on the same diagonal
+        assert!(same_diagonal(Squares::A1, Squares::H8));
+        // A2 and B3 are on the same diagonal
+        assert!(same_diagonal(Squares::A2, Squares::B3));
+        // A1 and A8 are not on the same diagonal
+        assert!(!same_diagonal(Squares::A1, Squares::A8));
+        // C1 and E3 are on the same diagonal
+        assert!(same_diagonal(Squares::C1, Squares::E3));
+        assert!(same_diagonal(Squares::A3, Squares::E7));
+    }
+
+    #[test]
+    fn test_same_anti_diagonal() {
+        // H1 and A8 are on the same anti-diagonal
+        assert!(same_anti_diagonal(Squares::H1, Squares::A8));
+        // A2 and B1 are on the same anti-diagonal
+        assert!(same_anti_diagonal(Squares::A2, Squares::B1)); // A2 (0) and B1 (9)
+        // A1 and A8 are not on the same anti-diagonal
+        assert!(!same_anti_diagonal(Squares::A1, Squares::A8));
+        // G2 and E4 are on the same anti-diagonal
+        assert!(same_anti_diagonal(Squares::G2, Squares::E4));
+    }
+}

--- a/ai-engine/src/game_bit_board/positions.rs
+++ b/ai-engine/src/game_bit_board/positions.rs
@@ -272,11 +272,11 @@ impl BBPositions {
 }
 
 pub fn same_rank(sq1: usize, sq2: usize) -> bool {
-    sq1 / 8 == sq2 / 8 // Divide by 8 to get the rank (row)
+    sq1 / 8 == sq2 / 8
 }
 
 pub fn same_file(sq1: usize, sq2: usize) -> bool {
-    sq1 % 8 == sq2 % 8 // Modulo 8 to get the file (column)
+    sq1 % 8 == sq2 % 8
 }
 
 pub fn same_diagonal(sq1: usize, sq2: usize) -> bool {
@@ -293,46 +293,32 @@ mod tests {
 
     #[test]
     fn test_same_rank() {
-        // A1 and H1 are on the same rank
         assert!(same_rank(Squares::A1, Squares::H1));
-        // A1 and A2 are not on the same rank
         assert!(!same_rank(Squares::A1, Squares::A2));
-        // D4 and G4 are on the same rank
         assert!(same_rank(Squares::D4, Squares::G4));
     }
 
     #[test]
     fn test_same_file() {
-        // A1 and A8 are on the same file
         assert!(same_file(Squares::A1, Squares::A8));
-        // A1 and B1 are not on the same file
         assert!(!same_file(Squares::A1, Squares::H1));
-        // D4 and D7 are on the same file
-        assert!(same_file(Squares::D4, Squares::D4 + 24)); // D4 (27) and D7 (27 + 24)
+        assert!(same_file(Squares::D4, Squares::D4 + 24));
     }
 
     #[test]
     fn test_same_diagonal() {
-        // A1 and H8 are on the same diagonal
         assert!(same_diagonal(Squares::A1, Squares::H8));
-        // A2 and B3 are on the same diagonal
         assert!(same_diagonal(Squares::A2, Squares::B3));
-        // A1 and A8 are not on the same diagonal
         assert!(!same_diagonal(Squares::A1, Squares::A8));
-        // C1 and E3 are on the same diagonal
         assert!(same_diagonal(Squares::C1, Squares::E3));
         assert!(same_diagonal(Squares::A3, Squares::E7));
     }
 
     #[test]
     fn test_same_anti_diagonal() {
-        // H1 and A8 are on the same anti-diagonal
         assert!(same_anti_diagonal(Squares::H1, Squares::A8));
-        // A2 and B1 are on the same anti-diagonal
-        assert!(same_anti_diagonal(Squares::A2, Squares::B1)); // A2 (0) and B1 (9)
-        // A1 and A8 are not on the same anti-diagonal
+        assert!(same_anti_diagonal(Squares::A2, Squares::B1));
         assert!(!same_anti_diagonal(Squares::A1, Squares::A8));
-        // G2 and E4 are on the same anti-diagonal
         assert!(same_anti_diagonal(Squares::G2, Squares::E4));
     }
 }

--- a/ai-engine/src/game_bit_board/positions.rs
+++ b/ai-engine/src/game_bit_board/positions.rs
@@ -241,6 +241,27 @@ impl BBPositions {
   pub const ROW_2: [u64; 8] = [BBPositions::A2, BBPositions::B2, BBPositions::C2, BBPositions::D2, BBPositions::E2, BBPositions::F2, BBPositions::G2, BBPositions::H2];
   pub const ROW_1: [u64; 8] = [BBPositions::A1, BBPositions::B1, BBPositions::C1, BBPositions::D1, BBPositions::E1, BBPositions::F1, BBPositions::G1, BBPositions::H1];
 
+  pub const ROW_8_BB: u64 = 0xff00000000000000;
+  pub const ROW_7_BB: u64 = 0xff000000000000;
+  pub const ROW_6_BB: u64 = 0xff0000000000;
+  pub const ROW_5_BB: u64 = 0xff00000000;
+  pub const ROW_4_BB: u64 = 0xff000000;
+  pub const ROW_3_BB: u64 = 0xff0000;
+  pub const ROW_2_BB: u64 = 0xff00;
+  pub const ROW_1_BB: u64 = 0xff;
+
+  pub fn get_row_bb(bb: u64) -> u64 {
+      for row in [BBPositions::ROW_8_BB, BBPositions::ROW_7_BB, BBPositions::ROW_6_BB,
+       BBPositions::ROW_5_BB, BBPositions::ROW_4_BB, BBPositions::ROW_3_BB,
+       BBPositions::ROW_2_BB,BBPositions::ROW_1_BB] {
+           if bb & row != 0 {
+               return row;
+           }
+       }
+
+       0
+  }
+
   pub fn is_en_passant_position(color: Color, bb_position: u64) -> bool {
     if color.is_white() {
       BBPositions::ROW_3.contains(&bb_position)

--- a/ai-engine/src/game_bit_board/utils/bitwise_utils.rs
+++ b/ai-engine/src/game_bit_board/utils/bitwise_utils.rs
@@ -1,4 +1,4 @@
-pub fn get_direction_to_square(from: usize, to: usize) -> fn(u64) -> u64 {
+pub fn get_direction_fn_to_square(from: usize, to: usize) -> fn(u64) -> u64 {
     let from_rank = from / 8;
     let from_file = from % 8;
     let to_rank = to / 8;
@@ -20,9 +20,8 @@ pub fn get_direction_to_square(from: usize, to: usize) -> fn(u64) -> u64 {
     }
 }
 
+#[inline(always)]
 pub fn to_bitboard_position(square: u64) -> u64 { 1 << square }
-
-pub fn to_decimal_position(square: u64) -> u64 { 1 >> square }
 
 const NOT_A_FILE: u64 = 0xfefefefefefefefe;
 const NOT_H_FILE: u64 = 0x7f7f7f7f7f7f7f7f;
@@ -36,24 +35,34 @@ const H1_A8_ANTIDIAGONAL: u64 = 0x0102040810204080;
 const LIGHT_SQUARES: u64 = 0x55AA55AA55AA55AA;
 const DARK_SQUARES: u64 = 0xAA55AA55AA55AA55;
 
+#[inline(always)]
 pub fn east_one(bb: u64) -> u64 { (bb << 1) & NOT_A_FILE }
 
+#[inline(always)]
 pub fn no_ea_one(bb: u64) -> u64 { (bb << 9) & NOT_A_FILE }
 
+#[inline(always)]
 pub fn so_ea_one(bb: u64) -> u64 { (bb >> 7) & NOT_A_FILE }
 
+#[inline(always)]
 pub fn west_one(bb: u64) -> u64 { (bb >> 1) & NOT_H_FILE }
 
+#[inline(always)]
 pub fn so_we_one(bb: u64) -> u64 { (bb >> 9) & NOT_H_FILE }
 
+#[inline(always)]
 pub fn no_we_one(bb: u64) -> u64 { (bb << 7) & NOT_H_FILE }
 
+#[inline(always)]
 pub fn south_one(bb: u64) -> u64 { bb >> 8 }
 
+#[inline(always)]
 pub fn north_one(bb: u64) -> u64 { bb << 8 }
 
+#[inline(always)]
 pub fn upper_bits(square: u64) -> u64 { !1 << square }
 
+#[inline(always)]
 pub fn lower_bits(square: u64) -> u64 { (1 << square) - 1 }
 
 pub fn get_direction_name(f: fn(u64) -> u64) -> &'static str {
@@ -80,6 +89,7 @@ pub fn get_direction_name(f: fn(u64) -> u64) -> &'static str {
     }
 }
 
+// Boworred from someone on StackOverflow, I missed the link
 static DEBRUIJ_T: &'static [u8] = &[
     0, 47, 1, 56, 48, 27, 2, 60, 57, 49, 41, 37, 28, 16, 3, 61, 54, 58, 35, 52, 50, 42, 21, 44, 38,
     32, 29, 23, 17, 11, 4, 62, 46, 55, 26, 59, 40, 36, 15, 53, 34, 51, 20, 43, 31, 22, 10, 45, 25,
@@ -110,7 +120,7 @@ pub fn pop_lsb(bits: &mut u64) -> u8 {
 mod tests {
     use crate::game_bit_board::{
         positions::BBPositions,
-        utils::bitwise_utils::{lower_bits, to_bitboard_position, to_decimal_position, upper_bits},
+        utils::bitwise_utils::{lower_bits, to_bitboard_position, upper_bits},
     };
 
     use super::{
@@ -120,11 +130,6 @@ mod tests {
     #[test]
     fn test_to_bitboard_position() {
         assert_eq!(BBPositions::A1, to_bitboard_position(0));
-    }
-
-    #[test]
-    fn test_to_decimal_position() {
-        assert_eq!(0, to_decimal_position(BBPositions::A1));
     }
 
     #[test]

--- a/ai-engine/src/game_bit_board/utils/bitwise_utils.rs
+++ b/ai-engine/src/game_bit_board/utils/bitwise_utils.rs
@@ -89,7 +89,7 @@ pub fn get_direction_name(f: fn(u64) -> u64) -> &'static str {
     }
 }
 
-// Boworred from someone on StackOverflow, I missed the link
+// Boworred from someone on StackOverflow, I lost the link
 static DEBRUIJ_T: &'static [u8] = &[
     0, 47, 1, 56, 48, 27, 2, 60, 57, 49, 41, 37, 28, 16, 3, 61, 54, 58, 35, 52, 50, 42, 21, 44, 38,
     32, 29, 23, 17, 11, 4, 62, 46, 55, 26, 59, 40, 36, 15, 53, 34, 51, 20, 43, 31, 22, 10, 45, 25,

--- a/ai-engine/src/game_bit_board/utils/bitwise_utils.rs
+++ b/ai-engine/src/game_bit_board/utils/bitwise_utils.rs
@@ -20,7 +20,6 @@ pub fn get_direction_to_square(from: usize, to: usize) -> fn(u64) -> u64 {
     }
 }
 
-
 pub fn to_bitboard_position(square: u64) -> u64 { 1 << square }
 
 pub fn to_decimal_position(square: u64) -> u64 { 1 >> square }
@@ -60,44 +59,31 @@ pub fn lower_bits(square: u64) -> u64 { (1 << square) - 1 }
 pub fn get_direction_name(f: fn(u64) -> u64) -> &'static str {
     let f = f as fn(u64) -> u64;
 
-    if f == east_one as fn(u64) -> u64{
+    if f == east_one as fn(u64) -> u64 {
         "east"
-    }
-    else if f == no_ea_one as fn(u64) -> u64 {
+    } else if f == no_ea_one as fn(u64) -> u64 {
         "north east"
-    }
-    else if f == so_ea_one as fn(u64) -> u64 {
+    } else if f == so_ea_one as fn(u64) -> u64 {
         "so east"
-    }
-    else if f == west_one as fn(u64) -> u64 {
+    } else if f == west_one as fn(u64) -> u64 {
         "west"
-    }
-    else if f == so_we_one as fn(u64) -> u64 {
+    } else if f == so_we_one as fn(u64) -> u64 {
         "so west"
-    }
-    else if f == no_we_one as fn(u64) -> u64 {
+    } else if f == no_we_one as fn(u64) -> u64 {
         "north west"
-    }
-    else if f == south_one as fn(u64) -> u64 {
+    } else if f == south_one as fn(u64) -> u64 {
         "south"
-    }
-    else if f == north_one as fn(u64) -> u64 {
+    } else if f == north_one as fn(u64) -> u64 {
         "north"
-    }
-    else {
+    } else {
         "unkwnown direction"
     }
 }
 
 static DEBRUIJ_T: &'static [u8] = &[
-    0, 47,  1, 56, 48, 27,  2, 60,
-    57, 49, 41, 37, 28, 16,  3, 61,
-    54, 58, 35, 52, 50, 42, 21, 44,
-    38, 32, 29, 23, 17, 11,  4, 62,
-    46, 55, 26, 59, 40, 36, 15, 53,
-    34, 51, 20, 43, 31, 22, 10, 45,
-    25, 39, 14, 33, 19, 30,  9, 24,
-    13, 18,  8, 12,  7,  6,  5, 63
+    0, 47, 1, 56, 48, 27, 2, 60, 57, 49, 41, 37, 28, 16, 3, 61, 54, 58, 35, 52, 50, 42, 21, 44, 38,
+    32, 29, 23, 17, 11, 4, 62, 46, 55, 26, 59, 40, 36, 15, 53, 34, 51, 20, 43, 31, 22, 10, 45, 25,
+    39, 14, 33, 19, 30, 9, 24, 13, 18, 8, 12, 7, 6, 5, 63,
 ];
 
 const DEBRUIJ_M: u64 = 0x03f7_9d71_b4cb_0a89;

--- a/ai-engine/src/game_bit_board/utils/board_utils.rs
+++ b/ai-engine/src/game_bit_board/utils/board_utils.rs
@@ -1,6 +1,6 @@
 use crate::game_bit_board::{
+    board::Board,
     enums::{Color, PieceType},
-    positions::BBPositions,
 };
 
 pub const BLACK_IDX: usize = 0;
@@ -21,18 +21,6 @@ pub const PIECE_INDEXES: [usize; 6] = [
     QUEENS_IDX,
     ROOKS_IDX,
 ];
-
-pub fn is_white_pawn_promotion(color: Color, from: u64, to: u64) -> bool {
-    color == Color::White && BBPositions::ROW_7.contains(&from) && BBPositions::ROW_8.contains(&to)
-}
-
-pub fn is_black_pawn_promotion(color: Color, from: u64, to: u64) -> bool {
-    color == Color::Black && BBPositions::ROW_2.contains(&from) && BBPositions::ROW_1.contains(&to)
-}
-
-pub fn is_pawn_promotion(color: Color, from: u64, to: u64) -> bool {
-    is_black_pawn_promotion(color, from, to) || is_white_pawn_promotion(color, from, to)
-}
 
 pub fn get_color_index(color: Color) -> usize {
     match color {
@@ -63,6 +51,22 @@ pub fn get_piece_type_from_index(index: usize) -> PieceType {
         ROOKS_IDX => PieceType::Rook,
         _ => PieceType::Empty,
     }
+}
+
+#[derive(Clone, Copy)]
+pub enum Side {
+    KingSide,
+    QueenSide,
+}
+
+pub fn get_castling_right_flag(color: Color, side: Side) -> u8 {
+    let castling_right = match (color, side) {
+        (Color::White, Side::KingSide) => Board::WHITE_KING_SIDE_CASTLING_RIGHT,
+        (Color::White, Side::QueenSide) => Board::WHITE_QUEEN_SIDE_CASTLING_RIGHT,
+        (Color::Black, Side::KingSide) => Board::BLACK_KING_SIDE_CASTLING_RIGHT,
+        (Color::Black, Side::QueenSide) => Board::BLACK_QUEEN_SIDE_CASTLING_RIGHT,
+    };
+    castling_right
 }
 
 #[cfg(test)]

--- a/ai-engine/src/game_bit_board/utils/utils.rs
+++ b/ai-engine/src/game_bit_board/utils/utils.rs
@@ -18,8 +18,8 @@ pub fn square_to_algebraic(square: usize) -> String {
     let algebraic_file = (b'a' + file) as char; // Convert file index to letter
     let algebraic_rank = (b'1' + rank) as char; // Convert rank index to number
 
-    format!("{}{}", algebraic_file, algebraic_rank) // Concatenate to form the
-                                                    // algebraic notation
+    // Concatenate to form the algebraic notation
+    format!("{}{}", algebraic_file, algebraic_rank)
 }
 
 pub fn get_piece_symbol(color: Color, piece_type: PieceType) -> String {

--- a/ai-engine/src/game_bit_board/zobrist/mod.rs
+++ b/ai-engine/src/game_bit_board/zobrist/mod.rs
@@ -1,2 +1,2 @@
 pub mod zobrist;
-pub mod zobrist_utils;
+mod zobrist_utils;

--- a/ai-engine/src/game_bit_board/zobrist/zobrist.rs
+++ b/ai-engine/src/game_bit_board/zobrist/zobrist.rs
@@ -5,55 +5,68 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use crate::game_bit_board::{
     board::Board,
     enums::{Color, PieceType},
-    positions::BBPositions,
+    utils::bitwise_utils::pop_lsb,
 };
 
-use super::zobrist_utils::get_piece_index;
+use super::zobrist_utils::{
+    get_piece_index, BLACK_KING_SIDE_CASTLE_INDEX, BLACK_QUEEN_SIDE_CASTLE_INDEX,
+    WHITE_KING_SIDE_CASTLE_INDEX, WHITE_QUEEN_SIDE_CASTLE_INDEX,
+};
+
+// https://www.chessprogramming.org/Zobrist_Hashing
+//
+// At program initialization, we generate an array of pseudorandom numbers:
+// 1. One number for each piece at each square
+// 2. One number to indicate the side to move is black
+// 3. Four numbers to indicate the castling rights, though usually 16 (2^4) are
+//    used for speed
+// 4. Eight numbers to indicate the file of a valid En passant square, if any
+//
+// This leaves us with an array with 781 (12*64 + 1 + 4 + 8) random numbers.
+// Since pawns don't happen on first and eighth rank, one might be fine with
+// 12*64 though.
 
 #[derive(Debug, Clone)]
 pub struct Zobrist {
-    black_can_king_castle: u64,
-    black_can_queen_castle: u64,
-    black_pawn_en_passant: u64,
+    board_hashes: [[u64; 64]; 12],
+    castling_rights_hash: [u64; 4],
+    en_passant_hash: [u64; 8],
     hash: u64,
-    table: Vec<Vec<u64>>,
-    white_can_king_castle: u64,
-    white_can_queen_castle: u64,
-    white_pawn_en_passant: u64,
-    white_to_move: u64,
+    side_to_move_hash: u64,
 }
 
 impl Zobrist {
     pub fn new() -> Self {
         let mut rng = StdRng::seed_from_u64(222);
 
-        let mut table = vec![vec![0u64; 12]; 64];
+        let mut board_hashes = [[0u64; 64]; 12];
 
-        for row in table.iter_mut() {
+        for row in board_hashes.iter_mut() {
             for j in 0..row.len() {
                 row[j] = rng.gen::<u64>();
             }
         }
 
-        let black_can_king_castle = rng.gen::<u64>();
-        let black_can_queen_castle = rng.gen::<u64>();
-        let black_pawn_en_passant = rng.gen::<u64>();
+        let side_to_move_hash: u64 = rng.gen::<u64>();
 
-        let white_can_king_castle = rng.gen::<u64>();
-        let white_can_queen_castle = rng.gen::<u64>();
-        let white_pawn_en_passant = rng.gen::<u64>();
-        let white_to_move = rng.gen::<u64>();
+        // Castling rights
+        let mut castling_rights_hash: [u64; 4] = [0; 4];
+        for i in 0..4 {
+            castling_rights_hash[i] = rng.gen::<u64>();
+        }
+
+        // En passant (8 possible files)
+        let mut en_passant_hash: [u64; 8] = [0; 8];
+        for i in 0..8 {
+            en_passant_hash[i] = rng.gen::<u64>();
+        }
 
         Self {
-            black_can_king_castle,
-            black_can_queen_castle,
-            black_pawn_en_passant,
+            board_hashes,
+            castling_rights_hash,
+            en_passant_hash,
             hash: 0,
-            table,
-            white_can_king_castle,
-            white_can_queen_castle,
-            white_pawn_en_passant,
-            white_to_move,
+            side_to_move_hash,
         }
     }
 
@@ -61,81 +74,88 @@ impl Zobrist {
 
     pub fn update_hash_on_move(
         &mut self, captured_piece: PieceType, color: Color, from_index: usize,
-        moved_piece: PieceType, to_index: usize,
+        moved_piece: PieceType, to_index: usize, promotion_piece: Option<PieceType>,
     ) {
         let moved_piece_index = get_piece_index(color, moved_piece);
 
         // XOR out the old position of the moved piece
-        self.hash ^= self.table[from_index][moved_piece_index];
-
-        // XOR in the new position of the moved piece
-        self.hash ^= self.table[to_index][moved_piece_index];
+        self.hash ^= self.board_hashes[moved_piece_index][from_index];
 
         // If a piece was captured, XOR it out
         if captured_piece != PieceType::Empty {
             let captured_piece_index = get_piece_index(color.opponent(), captured_piece);
 
-            self.hash ^= self.table[to_index][captured_piece_index];
+            self.hash ^= self.board_hashes[captured_piece_index][to_index];
         }
 
-        self.hash ^= self.white_to_move;
+        // XOR in the new position of the moved piece
+        if promotion_piece.is_some() {
+            self.hash ^=
+                self.board_hashes[get_piece_index(color, promotion_piece.unwrap())][to_index];
+        } else {
+            self.hash ^= self.board_hashes[moved_piece_index][to_index];
+        }
+
+        if color.opponent().is_black() {
+            self.hash ^= self.side_to_move_hash;
+        }
     }
 
-    pub fn update_hash_on_black_en_passant_change(&mut self) {
-        self.hash ^= self.black_pawn_en_passant;
-    }
+    pub fn update_en_passant_hash(&mut self, en_passant_square_bb: u64) {
+        let square = pop_lsb(&mut (en_passant_square_bb.clone())) as usize;
 
-    pub fn update_hash_on_white_en_passant_change(&mut self) {
-        self.hash ^= self.white_pawn_en_passant;
+        let file = square % 8;
+
+        self.hash ^= self.en_passant_hash[file];
     }
 
     pub fn update_hash_on_black_lose_king_side_castle(&mut self) {
-        self.hash ^= self.black_can_king_castle;
+        self.hash ^= self.castling_rights_hash[BLACK_KING_SIDE_CASTLE_INDEX];
     }
 
     pub fn update_hash_on_black_lose_queen_side_castle(&mut self) {
-        self.hash ^= self.black_can_queen_castle;
+        self.hash ^= self.castling_rights_hash[BLACK_QUEEN_SIDE_CASTLE_INDEX];
     }
 
     pub fn update_hash_on_white_lose_king_side_castle(&mut self) {
-        self.hash ^= self.white_can_king_castle;
+        self.hash ^= self.castling_rights_hash[WHITE_KING_SIDE_CASTLE_INDEX];
     }
 
     pub fn update_hash_on_white_lose_queen_side_castle(&mut self) {
-        self.hash ^= self.white_can_queen_castle;
+        self.hash ^= self.castling_rights_hash[WHITE_QUEEN_SIDE_CASTLE_INDEX];
     }
 
     pub fn compute_hash(&mut self, board: &Board) -> u64 {
         let mut hash = 0u64;
 
-        if board.get_side_to_move().is_white() {
-            hash ^= self.white_to_move;
+        if board.get_side_to_move().is_black() {
+            hash ^= self.side_to_move_hash;
         }
 
         if board.has_king_side_castle_right(Color::Black) {
-            hash ^= self.black_can_king_castle;
+            hash ^= self.castling_rights_hash[BLACK_KING_SIDE_CASTLE_INDEX];
         }
 
         if board.has_queen_side_castle_right(Color::Black) {
-            hash ^= self.black_can_queen_castle;
-        }
-
-        let en_passant_bb_position = board.get_en_passant_bb_position();
-
-        if BBPositions::is_en_passant_position(Color::Black, en_passant_bb_position) {
-            hash ^= self.black_pawn_en_passant;
-        }
-
-        if BBPositions::is_en_passant_position(Color::White, en_passant_bb_position) {
-            hash ^= self.white_pawn_en_passant;
+            hash ^= self.castling_rights_hash[BLACK_QUEEN_SIDE_CASTLE_INDEX];
         }
 
         if board.has_king_side_castle_right(Color::White) {
-            hash ^= self.white_can_king_castle;
+            hash ^= self.castling_rights_hash[WHITE_KING_SIDE_CASTLE_INDEX];
         }
 
         if board.has_queen_side_castle_right(Color::White) {
-            hash ^= self.white_can_queen_castle;
+            hash ^= self.castling_rights_hash[WHITE_QUEEN_SIDE_CASTLE_INDEX];
+        }
+
+        let mut en_passant_square_bb = board.get_en_passant_piece_square_bb();
+
+        if en_passant_square_bb != 0 {
+            let square = pop_lsb(&mut en_passant_square_bb) as usize;
+
+            let file = square % 8;
+
+            hash ^= self.en_passant_hash[file];
         }
 
         for square in 0..64_usize {
@@ -143,7 +163,7 @@ impl Zobrist {
             let piece_color = board.get_piece_color(square);
 
             if piece_type != PieceType::Empty {
-                hash ^= self.table[square][get_piece_index(piece_color, piece_type)];
+                hash ^= self.board_hashes[get_piece_index(piece_color, piece_type)][square];
             }
         }
 

--- a/ai-engine/src/game_bit_board/zobrist/zobrist.rs
+++ b/ai-engine/src/game_bit_board/zobrist/zobrist.rs
@@ -72,9 +72,7 @@ impl Zobrist {
 
     pub fn get_hash(&self) -> u64 { self.hash }
 
-    pub fn set_hash(&mut self, hash: u64) {
-        self.hash = hash
-    }
+    pub fn set_hash(&mut self, hash: u64) { self.hash = hash }
 
     pub fn update_hash_on_move(
         &mut self, captured_piece: PieceType, color: Color, from_index: usize,

--- a/ai-engine/src/game_bit_board/zobrist/zobrist.rs
+++ b/ai-engine/src/game_bit_board/zobrist/zobrist.rs
@@ -120,7 +120,7 @@ impl Zobrist {
             hash ^= self.black_can_queen_castle;
         }
 
-        let en_passant_bb_position = board.get_en_passant();
+        let en_passant_bb_position = board.get_en_passant_bb_position();
 
         if BBPositions::is_en_passant_position(Color::Black, en_passant_bb_position) {
             hash ^= self.black_pawn_en_passant;

--- a/ai-engine/src/game_bit_board/zobrist/zobrist.rs
+++ b/ai-engine/src/game_bit_board/zobrist/zobrist.rs
@@ -72,6 +72,10 @@ impl Zobrist {
 
     pub fn get_hash(&self) -> u64 { self.hash }
 
+    pub fn set_hash(&mut self, hash: u64) {
+        self.hash = hash
+    }
+
     pub fn update_hash_on_move(
         &mut self, captured_piece: PieceType, color: Color, from_index: usize,
         moved_piece: PieceType, to_index: usize, promotion_piece: Option<PieceType>,

--- a/ai-engine/src/game_bit_board/zobrist/zobrist_utils.rs
+++ b/ai-engine/src/game_bit_board/zobrist/zobrist_utils.rs
@@ -1,8 +1,3 @@
-// use crate::common::{
-//     enums::PieceType,
-//     piece_utils::{get_piece_type, is_white_piece},
-// };
-
 use crate::game_bit_board::enums::{Color, PieceType};
 
 pub const WHITE_BISHOP_INDEX: usize = 0;
@@ -19,6 +14,11 @@ pub const BLACK_PAWN_INDEX: usize = 9;
 pub const BLACK_QUEEN_INDEX: usize = 10;
 pub const BLACK_ROOK_INDEX: usize = 11;
 
+pub const BLACK_QUEEN_SIDE_CASTLE_INDEX: usize = 0;
+pub const BLACK_KING_SIDE_CASTLE_INDEX: usize = 1;
+pub const WHITE_QUEEN_SIDE_CASTLE_INDEX: usize = 2;
+pub const WHITE_KING_SIDE_CASTLE_INDEX: usize = 3;
+
 pub fn get_piece_index(color: Color, piece_type: PieceType) -> usize {
     if color.is_white() {
         match piece_type {
@@ -28,7 +28,7 @@ pub fn get_piece_index(color: Color, piece_type: PieceType) -> usize {
             PieceType::Pawn => WHITE_PAWN_INDEX,
             PieceType::Queen => WHITE_QUEEN_INDEX,
             PieceType::Rook => WHITE_ROOK_INDEX,
-            _ => 100,
+            _ => panic!("Invalid piece type encountered."),
         }
     } else {
         match piece_type {
@@ -38,7 +38,7 @@ pub fn get_piece_index(color: Color, piece_type: PieceType) -> usize {
             PieceType::Pawn => BLACK_PAWN_INDEX,
             PieceType::Queen => BLACK_QUEEN_INDEX,
             PieceType::Rook => BLACK_ROOK_INDEX,
-            _ => 100,
+            _ => panic!("Invalid piece type encountered."),
         }
     }
 }

--- a/ai-engine/src/main.rs
+++ b/ai-engine/src/main.rs
@@ -53,7 +53,7 @@ fn main() {
     let mut move_generator = MoveGenerator::new();
 
     loop {
-        let  moves = move_generator.get_moves(&mut board);
+        let moves = move_generator.get_moves(&mut board);
 
         // for (i, _move) in moves.iter().enumerate() {
         //     println!("{}: {}", i+1, _move.to_algebraic_notation());

--- a/ai-engine/src/main.rs
+++ b/ai-engine/src/main.rs
@@ -42,7 +42,7 @@ fn get_piece_attacks(from: usize, moves: &Vec<Move>) -> Vec<usize> {
 
 fn main() {
     rayon::ThreadPoolBuilder::new()
-        .num_threads(12)
+        .num_threads(6)
         .build_global()
         .unwrap();
 
@@ -50,7 +50,7 @@ fn main() {
     // r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -
     let mut board =
         Board::from_fen("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1");
-    let mut move_generator = MoveGenerator::new();
+    let move_generator = MoveGenerator::new();
 
     loop {
         let moves = move_generator.get_moves(&mut board);
@@ -69,7 +69,7 @@ fn main() {
 
         match depth {
             Ok(depth) => {
-                count_moves(&mut board, depth, true, &mut move_generator);
+                count_moves(&mut board, depth, true, &move_generator);
             }
             Err(_) => {
                 println!("Invalid option")

--- a/ai-engine/src/main.rs
+++ b/ai-engine/src/main.rs
@@ -49,11 +49,11 @@ fn main() {
     // "8/2p5/3p4/KP5r/1R2Pp1k/8/6P1/8 b - e3"
     // r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -
     let mut board =
-        Board::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -");
-    let move_generator = MoveGenerator::new();
+        Board::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q2/PPPBBPpP/R4K1R w kq - 2 2");
+    let mut move_generator = MoveGenerator::new();
 
     loop {
-        let moves = move_generator.get_moves(&mut board);
+        let  moves = move_generator.get_moves(&mut board);
 
         // for (i, _move) in moves.iter().enumerate() {
         //     println!("{}: {}", i+1, _move.to_algebraic_notation());
@@ -69,7 +69,7 @@ fn main() {
 
         match depth {
             Ok(depth) => {
-                count_moves(&mut board, depth, true, &move_generator);
+                count_moves(&mut board, depth, true, &mut move_generator);
             }
             Err(_) => {
                 println!("Invalid option")
@@ -115,7 +115,7 @@ fn main() {
         if _move.is_none() {
             println!("Invalid move!");
         } else {
-            board.move_piece(_move.unwrap().clone());
+            board.move_piece(_move.unwrap());
         }
     }
 }

--- a/ai-engine/src/main.rs
+++ b/ai-engine/src/main.rs
@@ -49,7 +49,7 @@ fn main() {
     // "8/2p5/3p4/KP5r/1R2Pp1k/8/6P1/8 b - e3"
     // r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -
     let mut board =
-        Board::from_fen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q2/PPPBBPpP/R4K1R w kq - 2 2");
+        Board::from_fen("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1");
     let mut move_generator = MoveGenerator::new();
 
     loop {

--- a/ai-engine/src/main.rs
+++ b/ai-engine/src/main.rs
@@ -85,7 +85,7 @@ fn main() {
 
         let input: String = get_input("\nSquare you want to move to (e.g. a1): ");
 
-        let _move;
+        let mut _move;
 
         if input.len() == 3 {
             // It's a promotion move
@@ -114,7 +114,9 @@ fn main() {
         if _move.is_none() {
             println!("Invalid move!");
         } else {
-            board.move_piece(_move.unwrap());
+            let mut _move = _move.unwrap().clone();
+
+            board.move_piece(&mut _move);
         }
     }
 }

--- a/ai-engine/src/main.rs
+++ b/ai-engine/src/main.rs
@@ -48,8 +48,7 @@ fn main() {
 
     // "8/2p5/3p4/KP5r/1R2Pp1k/8/6P1/8 b - e3"
     // r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -
-    let mut board =
-        Board::from_fen("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1");
+    let mut board = Board::from_fen("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1");
     let move_generator = MoveGenerator::new();
 
     loop {

--- a/ai-engine/src/main.rs
+++ b/ai-engine/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
 
     // "8/2p5/3p4/KP5r/1R2Pp1k/8/6P1/8 b - e3"
     // r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -
-    let mut board = Board::from_fen("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1");
+    let mut board = Board::from_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
     let move_generator = MoveGenerator::new();
 
     loop {


### PR DESCRIPTION
Don't even try understanding this PR. In summary:

1. Stopped making moves to check if they were valid
2. Added a struct to store attack data before even generating moves
3. Tried fixing Zobrist hash, there is still something small I can't figure it out yet
4. Optimized the unmake move functionality. I was using a vector for storing the history of the board state. That was obviously slow but I did it to save some time and kind of forgot to change it later. Now I see the huge difference.

The move generation is in fact faster. For initial position, the average runtime for depth 5, which searcher 4,865,609 positions, was **11 seconds**. After pre-calculating attack data and optimizing the unmake function, we now get the same result at around **270ms**.

THAT PUTS A SMILE IN ANY PROGRAMMER'S FACE!